### PR TITLE
Timeout issue when using EventStore.read_stream_forward\3

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -86,9 +86,9 @@ defmodule EventStore do
       If not set it will be limited to returning 1,000 events from the stream.
   """
   @spec read_stream_forward(String.t, non_neg_integer, non_neg_integer) :: {:ok, list(RecordedEvent.t)} | {:error, reason :: term}
-  def read_stream_forward(stream_uuid, start_version \\ 0, count \\ 1_000) do
+  def read_stream_forward(stream_uuid, start_version \\ 0, count \\ 1_000, timeout \\ 5_000) do
     with {:ok, _stream} <- EventStore.Streams.Supervisor.open_stream(stream_uuid) do
-      Stream.read_stream_forward(stream_uuid, start_version, count)
+      Stream.read_stream_forward(stream_uuid, start_version, count, timeout)
     else
       reply -> reply
     end

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -40,8 +40,8 @@ defmodule EventStore.Streams.Stream do
     GenServer.call(via_name(stream_uuid), {:append_to_stream, expected_version, events})
   end
 
-  def read_stream_forward(stream_uuid, start_version, count) do
-    GenServer.call(via_name(stream_uuid), {:read_stream_forward, start_version, count})
+  def read_stream_forward(stream_uuid, start_version, count, timeout \\ 5_000) do
+    GenServer.call(via_name(stream_uuid), {:read_stream_forward, start_version, count}, timeout)
   end
 
   def stream_forward(stream_uuid, start_version, read_batch_size) do


### PR DESCRIPTION
I am having a few issues when trying to read a large number of events from a stream (> 1,000). Obviously, I can just reduce the number of events to read and spread it out over many requests. However sometimes, my internet isn't the best (Australian internet can be shit) and reading a small number of events (~100) also fails. 

I would like to add a parameter or configuration option to the `read_stream_forward` method so that we can increase the `GenServer.call` timeout. 

The attached changes do it in a pretty crude manner, but it works for my purposes. I am open to suggestions on how we can clean it up. We should also add the timeout options to other similar methods such as `EventStore.read_all_streams_forward`.