### PR TITLE
Publish events directly to subscriptions

### DIFF
--- a/lib/event_store/publisher.ex
+++ b/lib/event_store/publisher.ex
@@ -7,27 +7,13 @@ defmodule EventStore.Publisher do
 
   alias EventStore.{Publisher,Registration,Storage,Subscriptions}
 
-  defmodule PendingEvents do
-    defstruct [
-      initial_event_number: nil,
-      last_event_number: nil,
-      stream_uuid: nil,
-      events: [],
-    ]
-  end
-
   defstruct [
-    last_published_event_number: 0,
-    pending_events: %{},
     serializer: nil,
   ]
 
   def start_link(serializer) do
-    {:ok, latest_event_number} = Storage.latest_event_number()
-
     GenServer.start_link(__MODULE__, %Publisher{
       serializer: serializer,
-      last_published_event_number: latest_event_number,
     }, name: __MODULE__)
   end
 
@@ -37,71 +23,9 @@ defmodule EventStore.Publisher do
 
   def init(%Publisher{} = state), do: {:ok, state}
 
-  def handle_cast(:notify_pending_events, %Publisher{last_published_event_number: last_published_event_number, pending_events: pending_events, serializer: serializer} = state) do
-    next_event_number = last_published_event_number + 1
-
-    state = case Map.get(pending_events, next_event_number) do
-      %PendingEvents{stream_uuid: stream_uuid, events: events, last_event_number: last_event_number} ->
-        :ok = Subscriptions.notify_events(stream_uuid, events, serializer)
-
-        state = %Publisher{state |
-          last_published_event_number: last_event_number,
-          pending_events: Map.delete(pending_events, next_event_number),
-        }
-
-        :ok = notify_pending_events(state)
-
-        state
-
-      nil ->
-        state
-    end
+  def handle_info({:notify_events, stream_uuid, events}, %Publisher{serializer: serializer} = state) do
+    :ok = Subscriptions.notify_events(stream_uuid, events, serializer)
 
     {:noreply, state}
   end
-
-  def handle_info({:notify_events, stream_uuid, events}, %Publisher{last_published_event_number: last_published_event_number, pending_events: pending_events, serializer: serializer} = state) do
-    expected_event_number = last_published_event_number + 1
-    initial_event_number = first_event_number(events)
-    last_event_number = last_event_number(events)
-
-    state = case initial_event_number do
-      ^expected_event_number ->
-        # events are in expected order, immediately notify subscribers
-        :ok = Subscriptions.notify_events(stream_uuid, events, serializer)
-
-        %Publisher{state |
-          last_published_event_number: last_event_number,
-        }
-
-      initial_event_number ->
-        # events are out of order, track pending events to be later published in order
-        pending = %PendingEvents{
-          initial_event_number: initial_event_number,
-          last_event_number: last_event_number,
-          stream_uuid: stream_uuid,
-          events: events,
-        }
-
-        state = %Publisher{state |
-          pending_events: Map.put(pending_events, initial_event_number, pending),
-        }
-
-        :ok = notify_pending_events(state)
-
-        state
-    end
-
-    {:noreply, state}
-  end
-
-  # Attempt to publish any pending events by sending a message to self.
-  defp notify_pending_events(%Publisher{pending_events: pending_events})
-    when pending_events == %{}, do: :ok
-
-  defp notify_pending_events(%Publisher{}),
-    do: GenServer.cast(self(), :notify_pending_events)
-
-  defp first_event_number([first | _]), do: first.event_number
-  defp last_event_number(events), do: List.last(events).event_number
 end

--- a/lib/event_store/publisher.ex
+++ b/lib/event_store/publisher.ex
@@ -5,7 +5,7 @@ defmodule EventStore.Publisher do
 
   use GenServer
 
-  alias EventStore.{Publisher,Registration,Storage,Subscriptions}
+  alias EventStore.{Publisher,Registration,Subscriptions}
 
   defstruct [
     serializer: nil,

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -1,6 +1,7 @@
 defmodule EventStore.Subscriptions do
   @moduledoc """
-  Pub/sub for subscribers interested in events appended to either a single stream or all streams
+  Pub/sub for subscribers interested in events appended to either a single
+  stream or all streams.
   """
 
   require Logger

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -127,7 +127,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
           next_state(:subscribed, data)
 
         ^expected_event ->
-          # subscriber has not yet ack'd last seen event so pending events
+          # subscriber has not yet ack'd last seen event so store pending events
           # until subscriber ready to receive (back pressure)
           data = %SubscriptionState{data |
             last_seen: last_event_number,

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -107,12 +107,12 @@ defmodule EventStore.Subscriptions.StreamSubscription do
   end
 
   defstate subscribed do
-    # notify events for single stream subscription
+    # notify events when subscribed
     defevent notify_events(events), data: %SubscriptionState{stream_uuid: stream_uuid, last_seen: last_seen, last_ack: last_ack, pending_events: pending_events, max_size: max_size} = data do
       expected_event = last_seen + 1
       next_ack = last_ack + 1
       first_event_number = events |> hd() |> subscription_provider(stream_uuid).event_number()
-      last_event_number = events |> List.last() |> subscription_provider(stream_uuid).event_number()
+      last_event_number = last_event_number(events, data)
 
       case first_event_number do
         ^next_ack ->
@@ -144,8 +144,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
           end
 
         _ ->
-          # received a different event than expected; must catch-up with all unseen events
-          next_state(:request_catch_up, %SubscriptionState{data | last_received: last_event_number})
+          next_state(:request_catch_up, data)
       end
     end
 
@@ -256,15 +255,20 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     Storage.unsubscribe_from_stream(stream_uuid, subscription_name)
   end
 
-  defp track_last_received(events, %SubscriptionState{stream_uuid: stream_uuid} = data) do
+  defp track_last_received(events, %SubscriptionState{} = data) do
     %SubscriptionState{data |
-      last_received: events |> List.last() |> subscription_provider(stream_uuid).event_number()
+      last_received: last_event_number(events, data),
     }
   end
 
-  # Fetch unseen events from the stream transition to `subscribed` state when no
-  # events are found or count of events is less than max buffer size so no
-  # further unseen events.
+  defp last_event_number(events, %SubscriptionState{stream_uuid: stream_uuid}) do
+    events
+    |> List.last()
+    |> subscription_provider(stream_uuid).event_number()
+  end
+
+  # Fetch unseen events from the stream, transition to `subscribed` state when
+  # stream ends
   defp catch_up_from_stream(%SubscriptionState{stream_uuid: stream_uuid, last_seen: last_seen} = data) do
     reply_to = self()
 
@@ -274,14 +278,15 @@ defmodule EventStore.Subscriptions.StreamSubscription do
         data
 
       unseen_event_stream ->
-        # stream unseen events to subscriber in a separate process
+        # stream unseen events to subscriber in a separate process so the
+        # subscription process is not blocked
         catch_up_pid = spawn_link(fn ->
           last_event =
             unseen_event_stream
             |> Stream.chunk_by(&chunk_by(&1))
             |> Stream.each(fn events ->
               notify_subscriber(data, events)
-              wait_for_ack(stream_uuid, events)
+              wait_for_ack(events, data)
             end)
             |> Stream.map(&Enum.at(&1, -1))
             |> Enum.at(-1)
@@ -300,10 +305,9 @@ defmodule EventStore.Subscriptions.StreamSubscription do
   end
 
   # wait until the subscriber ack's the last sent event
-  defp wait_for_ack(stream_uuid, events) when is_list(events) do
+  defp wait_for_ack(events, %SubscriptionState{} = data) when is_list(events) do
     events
-    |> List.last()
-    |> subscription_provider(stream_uuid).event_number()
+    |> last_event_number(data)
     |> wait_for_ack()
   end
 
@@ -376,8 +380,10 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     %SubscriptionState{data| last_ack: ack}
   end
 
-  # An `ack` can be a single integer, indicating an `event_number` or `stream_version`, or a tuple containing both, as `{event_number, stream_version}`.
-  # This function extracts the relevant value depending upon the type of subscription (all / single stream).
+  # An `ack` can be a single integer, indicating an `event_number` or
+  # `stream_version`, or a tuple containing both, as `{event_number, stream_version}`.
+  # This function extracts the relevant value depending upon the type of
+  # subscription (all / single stream).
   defp extract_ack(_stream_uuid, ack) when is_integer(ack),
     do: ack
 

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -144,7 +144,6 @@ defmodule EventStore.Streams.SingleStreamTest do
       assert length(received_events) == 3
     end
 
-    @tag :ignore
     test "from current should receive only new events", context do
       {:ok, _subscription} = Stream.subscribe_to_stream(context[:stream_uuid], @subscription_name, self(), start_from: :current)
 

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -1,4 +1,4 @@
-defmodule EventStore.Subscriptions.SubscribeToStream do
+defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   use EventStore.StorageCase
 
   alias EventStore.{EventFactory,ProcessHelper,Wait}

--- a/test/subscriptions/subscription_back_pressure_test.exs
+++ b/test/subscriptions/subscription_back_pressure_test.exs
@@ -48,6 +48,7 @@ defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
       append_to_stream(stream1_uuid, 3)
       append_to_stream(stream2_uuid, 3)
 
+      # notify the subscription with unexpected events
       unexpected_events = EventFactory.create_recorded_events(5, stream1_uuid, 999)
       Subscription.notify_events(subscription, unexpected_events)
 
@@ -77,8 +78,6 @@ defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
 
     with {:ok, _stream} <- Streams.Supervisor.open_stream(stream_uuid) do
       :ok = Stream.append_to_stream(stream_uuid, 0, events)
-
-      :timer.sleep 100
     end
   end
 

--- a/test/subscriptions/subscription_back_pressure_test.exs
+++ b/test/subscriptions/subscription_back_pressure_test.exs
@@ -1,0 +1,99 @@
+defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
+  use EventStore.StorageCase
+
+  alias EventStore.{EventFactory,Wait}
+  alias EventStore.{Streams,Subscriptions}
+  alias EventStore.Subscriptions.Subscription
+  alias EventStore.Streams.Stream
+
+  setup do
+    subscription_name = UUID.uuid4()
+
+    {:ok, %{subscription_name: subscription_name}}
+  end
+
+  describe "subscription over capacity" do
+    test "should receive events once caught up", %{subscription_name: subscription_name} do
+      stream1_uuid = UUID.uuid4()
+      stream2_uuid = UUID.uuid4()
+      stream3_uuid = UUID.uuid4()
+      stream4_uuid = UUID.uuid4()
+
+      {:ok, subscription} = subscribe_to_all_streams(subscription_name, self(), max_size: 5)
+
+      append_to_stream(stream1_uuid, 5)
+      append_to_stream(stream2_uuid, 5)
+      append_to_stream(stream3_uuid, 5)
+
+      receive_and_ack(subscription, stream1_uuid)
+
+      append_to_stream(stream4_uuid, 5)
+
+      receive_and_ack(subscription, stream2_uuid)
+      receive_and_ack(subscription, stream3_uuid)
+      receive_and_ack(subscription, stream4_uuid)
+
+      refute_receive {:events, _events}
+    end
+
+    test "should handle unexpected event", %{subscription_name: subscription_name} do
+      stream1_uuid = UUID.uuid4()
+      stream2_uuid = UUID.uuid4()
+      stream3_uuid = UUID.uuid4()
+      stream4_uuid = UUID.uuid4()
+      stream5_uuid = UUID.uuid4()
+
+      {:ok, subscription} = subscribe_to_all_streams(subscription_name, self(), max_size: 5)
+
+      append_to_stream(stream1_uuid, 3)
+      append_to_stream(stream2_uuid, 3)
+
+      unexpected_events = EventFactory.create_recorded_events(5, stream1_uuid, 999)
+      Subscription.notify_events(subscription, unexpected_events)
+
+      append_to_stream(stream3_uuid, 3)
+      append_to_stream(stream4_uuid, 3)
+      append_to_stream(stream5_uuid, 3)
+
+      receive_and_ack(subscription, stream1_uuid)
+      receive_and_ack(subscription, stream2_uuid)
+      receive_and_ack(subscription, stream3_uuid)
+      receive_and_ack(subscription, stream4_uuid)
+      receive_and_ack(subscription, stream5_uuid)
+
+      refute_receive {:events, _events}
+    end
+  end
+
+  def receive_and_ack(subscription, expected_stream_uuid) do
+    assert_receive {:events, received_events}
+    assert Enum.all?(received_events, fn event -> event.stream_uuid == expected_stream_uuid end)
+
+    Subscription.ack(subscription, received_events)
+  end
+
+  defp append_to_stream(stream_uuid, event_count) do
+    events = EventFactory.create_events(event_count)
+
+    with {:ok, _stream} <- Streams.Supervisor.open_stream(stream_uuid) do
+      :ok = Stream.append_to_stream(stream_uuid, 0, events)
+
+      :timer.sleep 100
+    end
+  end
+
+  # subscribe to all streams and wait for the subscription to be subscribed
+  defp subscribe_to_all_streams(subscription_name, subscriber, opts) do
+    with {:ok, subscription} <- Subscriptions.subscribe_to_all_streams(subscription_name, subscriber, opts) do
+      wait_until_subscribed(subscription)
+
+      {:ok, subscription}
+    end
+  end
+
+  defp wait_until_subscribed(subscription) do
+    Wait.until(fn ->
+      assert Subscription.subscribed?(subscription)
+    end)
+  end
+end


### PR DESCRIPTION
Don't reorder events using the Publisher process, just send them directly to subscriptions and have them handle out-of-order events. 

This simplifies event publishing, especially when Event Store is run distributed on a cluster.