### PR TITLE
Initializer Transaction

### DIFF
--- a/lib/event_store/storage/initializer.ex
+++ b/lib/event_store/storage/initializer.ex
@@ -8,6 +8,13 @@ defmodule EventStore.Storage.Initializer do
   def reset!(conn),
     do: execute(conn, Statements.reset())
 
-  defp execute(conn, statements),
-    do: Enum.each(statements, &(Postgrex.query!(conn, &1, [], pool: DBConnection.Poolboy)))
+  defp execute(conn, statements) do
+    statements
+    |> wrap_transaction
+    |> Enum.each(&(Postgrex.query!(conn, &1, [], pool: DBConnection.Poolboy)))
+  end
+
+  defp wrap_transaction(statements) do
+    ["BEGIN"] ++ statements ++ ["COMMIT"]
+  end
 end


### PR DESCRIPTION
Hey @slashdotdash 

When I tried running `mix event_store.init` on an existing database it failed because the `schema_migrations` table already existed, which is perfectly fine. Problematically though it left a bunch of tables and stuff in the database, because it didn't fail until part way through the initialization process.

This PR wraps the init statement sets in a transaction so that the database isn't left in a partial state on failure.