### PR TITLE
Use PostgreSQL advisory locks to enforce only one subscription instance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replace `:info` level logging with `:debug` ([#90](https://github.com/commanded/eventstore/issues/90)).
 - Dealing better with Poison dependancy ([#91](https://github.com/commanded/eventstore/issues/91)).
 - Publish events directly to subscriptions ([#93](https://github.com/commanded/eventstore/pull/93)).
+- Use PostgreSQL advisory locks to enforce only one subscription instance ([#98](https://github.com/commanded/eventstore/pull/98)).
 
 ## v0.13.2
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,6 +3,8 @@ use Mix.Config
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 
+config :mix_test_watch, clear: true
+
 config :eventstore, EventStore.Storage,
   serializer: EventStore.TermSerializer,
   username: "postgres",

--- a/config/distributed.exs
+++ b/config/distributed.exs
@@ -19,7 +19,8 @@ config :eventstore, EventStore.Storage,
 
 config :eventstore,
   registry: :distributed,
-  restart_stream_timeout: 1_000
+  restart_stream_timeout: 1_000,
+  subscription_retry_interval: 1_000
 
 config :swarm,
   nodes: [:"node1@127.0.0.1", :"node2@127.0.0.1", :"node3@127.0.0.1"],

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -18,5 +18,6 @@ config :eventstore, EventStore.Storage,
   pool_overflow: 0
 
 config :eventstore,
+  column_data_type: "jsonb",
   registry: :local,
-  column_data_type: "jsonb"
+  subscription_retry_interval: 1_000

--- a/config/local.exs
+++ b/config/local.exs
@@ -17,4 +17,5 @@ config :eventstore, EventStore.Storage,
   pool_overflow: 0
 
 config :eventstore,
-  registry: :local
+  registry: :local,
+  subscription_retry_interval: 1_000

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,4 +17,5 @@ config :eventstore, EventStore.Storage,
   pool_overflow: 0
 
 config :eventstore,
-  registry: :local
+  registry: :local,
+  subscription_retry_interval: 1_000

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -290,6 +290,12 @@ WHERE stream_uuid = $1 AND subscription_name = $2;
 """
   end
 
+  def try_advisory_lock do
+"""
+SELECT pg_try_advisory_lock($1);
+"""
+  end
+
   def ack_last_seen_event do
 """
 UPDATE subscriptions

--- a/lib/event_store/storage.ex
+++ b/lib/event_store/storage.ex
@@ -79,28 +79,37 @@ defmodule EventStore.Storage do
   unique name and starting position (event number or stream version).
   """
   def subscribe_to_stream(stream_uuid, subscription_name, start_from_event_number \\ nil, start_from_stream_version \\ nil) do
-    Subscription.subscribe_to_stream(@event_store, stream_uuid, subscription_name, start_from_event_number, start_from_stream_version)
+    Subscription.subscribe_to_stream(@event_store, stream_uuid, subscription_name, start_from_event_number, start_from_stream_version, pool: DBConnection.Poolboy)
+  end
+
+  @doc """
+  Attempt to acquire an exclusive lock for the given subscription id. Uses
+  PostgreSQL's advisory locks[1] to provide session level locking.
+  [1] https://www.postgresql.org/docs/current/static/explicit-locking.html#ADVISORY-LOCKS
+  """
+  def try_acquire_exclusive_lock(subscription_id) do
+    Subscription.try_acquire_exclusive_lock(@event_store, subscription_id, pool: DBConnection.Poolboy)
   end
 
   @doc """
   Acknowledge receipt of an event by its number, for a single subscription.
   """
   def ack_last_seen_event(stream_uuid, subscription_name, last_seen_event_number, last_seen_stream_version) do
-    Subscription.ack_last_seen_event(@event_store, stream_uuid, subscription_name, last_seen_event_number, last_seen_stream_version)
+    Subscription.ack_last_seen_event(@event_store, stream_uuid, subscription_name, last_seen_event_number, last_seen_stream_version, pool: DBConnection.Poolboy)
   end
 
   @doc """
   Unsubscribe from an existing named subscription to a stream.
   """
   def unsubscribe_from_stream(stream_uuid, subscription_name) do
-    Subscription.unsubscribe_from_stream(@event_store, stream_uuid, subscription_name)
+    Subscription.unsubscribe_from_stream(@event_store, stream_uuid, subscription_name, pool: DBConnection.Poolboy)
   end
 
   @doc """
   Get all known subscriptions, to any stream.
   """
   def subscriptions do
-    Subscription.subscriptions(@event_store)
+    Subscription.subscriptions(@event_store, pool: DBConnection.Poolboy)
   end
 
   @doc """

--- a/lib/event_store/storage/subscription.ex
+++ b/lib/event_store/storage/subscription.ex
@@ -94,7 +94,7 @@ defmodule EventStore.Storage.Subscription do
     end
 
     defp handle_response({:error, %Postgrex.Error{postgres: %{code: :unique_violation}}}, stream_uuid, subscription_name) do
-      _ = Logger.warn(fn -> "Failed to create subscription on stream #{stream_uuid} named #{subscription_name}, already exists" end)
+      _ = Logger.debug(fn -> "Failed to create subscription on stream #{stream_uuid} named #{subscription_name}, already exists" end)
       {:error, :subscription_already_exists}
     end
 

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -52,7 +52,7 @@ defmodule EventStore.Subscriptions do
 
   defp notify_subscribers(stream_uuid, events) do
     Registry.dispatch(EventStore.Subscriptions.PubSub, stream_uuid, fn subscribers ->
-      for {subscription, {module, function}} <- subscribers, do: apply(module, function, [subscription, events])
+      for {pid, _} <- subscribers, do: send(pid, {:notify_events, events})
     end)
   end
 end

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -187,11 +187,12 @@ defmodule EventStore.Subscriptions.Subscription do
     {:ok, _} = Registry.register(EventStore.Subscriptions.PubSub, stream_uuid, [])
   end
 
-  # get the delay between subscription attempts, in milliseconds, from app
-  # config. Default value is one minute.
+  # Get the delay between subscription attempts, in milliseconds, from app
+  # config. The default value is one minute and minimum allowed value is one
+  # second.
   defp subscription_retry_interval do
     case Application.get_env(:eventstore, :subscription_retry_interval) do
-      interval when is_integer(interval) -> interval
+      interval when is_integer(interval) and interval > 0 -> min(interval, 1_000)
       _ -> 60_000
     end
   end

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -2,9 +2,11 @@ defmodule EventStore.Subscriptions.SubscriptionState do
   @moduledoc false
   defstruct [
     catch_up_pid: nil,
+    conn: nil,
     stream_uuid: nil,
     subscription_name: nil,
     subscriber: nil,
+    subscription_id: nil,
     mapper: nil,
     last_seen: 0,
     last_ack: 0,

--- a/lib/event_store/subscriptions/supervisor.ex
+++ b/lib/event_store/subscriptions/supervisor.ex
@@ -7,8 +7,8 @@ defmodule EventStore.Subscriptions.Supervisor do
 
   alias EventStore.Subscriptions.Subscription
 
-  def start_link(_) do
-    Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
+  def start_link(postgrex_config) do
+    Supervisor.start_link(__MODULE__, postgrex_config, name: __MODULE__)
   end
 
   def subscribe_to_stream(stream_uuid, subscription_name, subscriber, subscription_opts) do
@@ -28,9 +28,9 @@ defmodule EventStore.Subscriptions.Supervisor do
     end
   end
 
-  def init(_) do
+  def init(postgrex_config) do
     children = [
-      worker(Subscription, [], restart: :temporary),
+      worker(Subscription, [postgrex_config], restart: :temporary),
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -11,11 +11,14 @@ defmodule EventStore.Supervisor do
   end
 
   def init([config, serializer]) do
+    postgrex_config = postgrex_opts(config)
+    subscription_postgrex_config = subscription_postgrex_opts(config)
+
     children = [
-      {Postgrex, postgrex_opts(config)},
+      {Postgrex, postgrex_config},
       Supervisor.child_spec({Registry, keys: :unique, name: EventStore.Subscriptions.Subscription}, id: EventStore.Subscriptions.Subscription),
       Supervisor.child_spec({Registry, keys: :duplicate, name: EventStore.Subscriptions.PubSub, partitions: System.schedulers_online}, id: EventStore.Subscriptions.PubSub),
-      {EventStore.Subscriptions.Supervisor, []},
+      {EventStore.Subscriptions.Supervisor, subscription_postgrex_config},
       {EventStore.Streams.Supervisor, serializer},
       {EventStore.Publisher, serializer},
     ] ++ Registration.child_spec()
@@ -23,25 +26,32 @@ defmodule EventStore.Supervisor do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
+  @default_postgrex_opts [
+    :username,
+    :password,
+    :database,
+    :hostname,
+    :port,
+    :types,
+    :ssl,
+    :ssl_opts
+  ]
+
   defp postgrex_opts(config) do
     [
       pool_size: 10,
-      pool_overflow: 0,
+      pool_overflow: 0
     ]
     |> Keyword.merge(config)
-    |> Keyword.take([
-      :username,
-      :password,
-      :database,
-      :hostname,
-      :port,
+    |> Keyword.take(@default_postgrex_opts ++ [
       :pool,
       :pool_size,
-      :pool_overflow,
-      :types,
-      :ssl,
-      :ssl_opts,
+      :pool_overflow
     ])
     |> Keyword.merge(name: :event_store)
+  end
+
+  defp subscription_postgrex_opts(config) do
+    Keyword.take(config, @default_postgrex_opts)
   end
 end

--- a/test/storage/subscription_persistence_test.exs
+++ b/test/storage/subscription_persistence_test.exs
@@ -1,7 +1,7 @@
 defmodule EventStore.Storage.SubscriptionPersistenceTest do
   use EventStore.StorageCase
 
-  alias EventStore.Storage
+  alias EventStore.{ProcessHelper,Storage}
 
   @all_stream "$all"
   @subscription_name "test_subscription"
@@ -24,7 +24,7 @@ defmodule EventStore.Storage.SubscriptionPersistenceTest do
 
   test "list subscriptions" do
     {:ok, subscription} = Storage.subscribe_to_stream(@all_stream, @subscription_name)
-    {:ok, subscriptions} = Storage.subscriptions
+    {:ok, subscriptions} = Storage.subscriptions()
 
     assert length(subscriptions) > 0
     assert Enum.member?(subscriptions, subscription)
@@ -39,6 +39,37 @@ defmodule EventStore.Storage.SubscriptionPersistenceTest do
 
     {:ok, subscriptions} = Storage.subscriptions
     assert length(subscriptions) == initial_length
+  end
+
+  test "acquire exclusive subscription lock" do
+    assert :ok = Storage.try_acquire_exclusive_lock(1)
+  end
+
+  test "acquire and release lock by connection" do
+    config =
+      EventStore.configuration()
+      |> EventStore.Config.parse()
+      |> Keyword.drop([:pool, :pool_size, :pool_overflow])
+
+    {:ok, conn1} = Postgrex.start_link(config)
+    {:ok, conn2} = Postgrex.start_link(config)
+
+    # conn1 acquire lock
+    assert :ok = Storage.Subscription.try_acquire_exclusive_lock(conn1, 1)
+
+    # conn2 cannot acquire lock
+    assert {:error, :lock_already_taken} = Storage.Subscription.try_acquire_exclusive_lock(conn2, 1)
+
+    # conn1 can acquire same lock multiple times
+    assert :ok = Storage.Subscription.try_acquire_exclusive_lock(conn1, 1)
+
+    # shutdown conn1 process should release its locks
+    ProcessHelper.shutdown(conn1)
+
+    # conn2 can now acquire lock
+    assert :ok = Storage.Subscription.try_acquire_exclusive_lock(conn2, 1)
+
+    ProcessHelper.shutdown(conn2)    
   end
 
   test "remove subscription when not found should not fail" do

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -33,7 +33,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
       subscription = create_subscription(context)
 
-      assert subscription.state == :request_catch_up
+      assert subscription.state == :subscribe_to_events
       assert subscription.data.subscription_name == @subscription_name
       assert subscription.data.subscriber == self()
       assert subscription.data.last_seen == 0
@@ -45,7 +45,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
       subscription = create_subscription(context, start_from_stream_version: 2)
 
-      assert subscription.state == :request_catch_up
+      assert subscription.state == :subscribe_to_events
       assert subscription.data.subscription_name == @subscription_name
       assert subscription.data.subscriber == self()
       assert subscription.data.last_seen == 2
@@ -70,6 +70,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
       subscription =
         create_subscription(context)
+        |> StreamSubscription.subscribed()
         |> StreamSubscription.catch_up()
 
       assert subscription.state == :catching_up
@@ -85,6 +86,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     test "unseen persisted events", %{recorded_events: recorded_events} = context do
       subscription =
         create_subscription(context)
+        |> StreamSubscription.subscribed()
         |> StreamSubscription.catch_up()
 
       assert subscription.state == :catching_up
@@ -107,6 +109,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     test "confirm subscription caught up to persisted events", context do
       subscription =
         create_subscription(context)
+        |> StreamSubscription.subscribed()
         |> StreamSubscription.catch_up()
 
       assert subscription.state == :catching_up
@@ -134,6 +137,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
     subscription =
       create_subscription(context)
+      |> StreamSubscription.subscribed()
       |> StreamSubscription.catch_up()
       |> StreamSubscription.caught_up(0)
       |> StreamSubscription.notify_events(events)
@@ -159,6 +163,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
       subscription =
         create_subscription(context)
+        |> StreamSubscription.subscribed()
         |> StreamSubscription.catch_up()
 
       assert subscription.state == :catching_up
@@ -177,6 +182,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     test "should replay events when not acknowledged", context do
       subscription =
         create_subscription(context)
+        |> StreamSubscription.subscribed()
         |> StreamSubscription.catch_up()
 
       assert subscription.state == :catching_up
@@ -222,6 +228,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
   defp subscribe_to_stream(context) do
     subscription =
       create_subscription(context)
+      |> StreamSubscription.subscribed()
       |> StreamSubscription.catch_up()
 
     assert subscription.state == :catching_up
@@ -247,6 +254,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
     subscription =
       create_subscription(context)
+      |> StreamSubscription.subscribed()
       |> StreamSubscription.catch_up()
       |> StreamSubscription.caught_up(0)
       |> StreamSubscription.notify_events(initial_events)

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -20,12 +20,11 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       events = EventFactory.create_events(3)
 
       {:ok, _stream} = Streams.Supervisor.open_stream(stream_uuid)
-
       {:ok, _subscription} = subscribe_to_stream(stream_uuid, subscription_name, self())
 
       :ok = Stream.append_to_stream(stream_uuid, 0, events)
-      assert_receive {:events, received_events}
 
+      assert_receive {:events, received_events}
       assert pluck(received_events, :event_number) == [4, 5, 6]
       assert pluck(received_events, :stream_uuid) == [stream_uuid, stream_uuid, stream_uuid]
       assert pluck(received_events, :stream_version) == [1, 2, 3]

--- a/test/support/collecting_subscriber.ex
+++ b/test/support/collecting_subscriber.ex
@@ -1,0 +1,48 @@
+defmodule EventStore.Support.CollectingSubscriber do
+  use GenServer
+
+  alias EventStore.Subscriptions
+  alias EventStore.Subscriptions.Subscription
+
+  def start_link(subscription_name) do
+    GenServer.start_link(__MODULE__, subscription_name)
+  end
+
+  def received_events(subscriber) do
+    GenServer.call(subscriber, {:received_events})
+  end
+
+  def subscribed?(subscriber) do
+    GenServer.call(subscriber, {:subscribed?})
+  end
+
+  def unsubscribe(subscriber) do
+    GenServer.call(subscriber, {:unsubscribe})
+  end
+
+  def init(subscription_name) do
+    {:ok, subscription} = Subscriptions.subscribe_to_all_streams(subscription_name, self())
+
+    {:ok, %{events: [], subscription: subscription, subscription_name: subscription_name}}
+  end
+
+  def handle_call({:received_events}, _from, %{events: events} = state) do
+    {:reply, events, state}
+  end
+
+  def handle_call({:subscribed?}, _from, %{subscription: subscription} = state) do
+    reply = Subscription.subscribed?(subscription)
+    {:reply, reply, state}
+  end
+
+  def handle_call({:unsubscribe}, _from, %{subscription_name: subscription_name} = state) do
+    Subscriptions.unsubscribe_from_all_streams(subscription_name)
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:events, received_events}, %{events: events, subscription: subscription} = state) do
+    Subscription.ack(subscription, received_events)
+
+    {:noreply, %{state | events: events ++ received_events}}
+  end
+end

--- a/test/support/wait.ex
+++ b/test/support/wait.ex
@@ -1,5 +1,5 @@
 defmodule EventStore.Wait do
-  def until(fun), do: until(500, fun)
+  def until(fun), do: until(1_000, fun)
 
   def until(0, fun), do: fun.()
 


### PR DESCRIPTION
PostgreSQL's `pg_try_advisory_lock` function is used to acquire a session lock on the subscription id to guarantee that only once uniquely named subscription instance can run.

Each subscription now has its own connection. When the subscription process goes down, the connection will terminate and its lock will be released.