### PR TITLE
Subscription notification message once successfully subscribed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Remove stream process ([#99](https://github.com/commanded/eventstore/pull/99)).
 - Use PostgreSQL's `NOTIFY` / `LISTEN` for event pub/sub ([#100](https://github.com/commanded/eventstore/pull/100)).
 - Link existing events to another stream ([#103](https://github.com/commanded/eventstore/pull/103)).
+- Subscription notification message once successfully subscribed ([#104](https://github.com/commanded/eventstore/pull/104)).
 
 ## v0.13.2
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ MIT License
 Append events to a stream:
 
 ```elixir
+defmodule ExampleEvent, do: defstruct [:key]
+
 stream_uuid = UUID.uuid4()
 expected_version = 0
 events = [
@@ -70,12 +72,30 @@ Subscribe to events appended to all streams:
 ```elixir
 {:ok, subscription} = EventStore.subscribe_to_all_streams("example_subscription", self())
 
+# receive notification once subscription has successfully subscribed
 receive do
-  {:events, events} ->
-    # ... process events & ack receipt    
-    EventStore.ack(subscription, events)
+  {:subscribed, ^subscription} ->
+    IO.puts "Successfully subscribed to all streams"
 end
+
+receive_loop = fn loop ->
+  # receive a batch of events appended to the event store
+  receive do
+    {:events, events} ->
+      IO.puts "Received events: #{inspect events}"
+
+      # ack successful receipt of events
+      EventStore.ack(subscription, events)
+  end
+
+  loop.(loop)
+end
+
+# infinite receive loop
+receive_loop.(receive_loop)
 ```
+
+In production use you would use a [`GenServer` subscriber process](guides/Subscriptions.md#example-subscriber) and the `handle_info/2` callback to receive events.
 
 More: [Subscribe to streams](guides/Subscriptions.md)
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Subscribe to events appended to all streams:
 ```elixir
 {:ok, subscription} = EventStore.subscribe_to_all_streams("example_subscription", self())
 
-# receive notification once subscription has successfully subscribed
+# wait for the subscription confirmation
 receive do
   {:subscribed, ^subscription} ->
     IO.puts "Successfully subscribed to all streams"

--- a/guides/Subscriptions.md
+++ b/guides/Subscriptions.md
@@ -2,11 +2,11 @@
 
 Subscriptions to a stream will guarantee *at least once* delivery of every persisted event. Each subscription may be independently paused, then later resumed from where it stopped.
 
-A subscription can be created to receive events published from a single or all streams.
+A subscription can be created to receive events appended to a single or all streams.
 
-Events are received in batches after being persisted to storage. Each batch contains events from a single stream and for the same correlation id.
+Events are received in batches after being persisted to storage. A batch contains the events appended to a single stream using `EventStore.append_to_stream/4`.
 
-Subscriptions must be uniquely named and support a single subscriber. Attempting to connect two subscribers to the same subscription will return an error.
+Subscriptions must be uniquely named and support a single subscriber. Attempting to connect two subscribers to the same subscription will return an `{:error, :subscription_already_exists}` error.
 
 ## Event pub/sub
 
@@ -53,6 +53,7 @@ Subscribe to events appended to all streams:
 ```elixir
 {:ok, subscription} = EventStore.subscribe_to_all_streams("example_all_subscription", self())
 
+# wait for the subscription confirmation
 receive do
   {:subscribed, ^subscription} ->
     IO.puts "Successfully subscribed to all streams"
@@ -81,6 +82,7 @@ Subscribe to events appended to a *single* stream:
 stream_uuid = UUID.uuid4()
 {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, "example_single_subscription", self())
 
+# wait for the subscription confirmation
 receive do
   {:subscribed, ^subscription} ->
     IO.puts "Successfully subscribed to single stream"
@@ -128,6 +130,7 @@ end
 
 {:ok, subscription} = EventStore.subscribe_to_all_streams("example_subscription", self(), mapper: mapper)
 
+# wait for the subscription confirmation
 receive do
   {:subscribed, ^subscription} ->
     IO.puts "Successfully subscribed to all streams"

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -250,6 +250,34 @@ defmodule EventStore do
         to the subscriber.
 
   Returns `{:ok, subscription}` when subscription succeeds.
+
+  ## Notification messages
+
+  Subscribers will initially receive a `{:subscribed, subscription}` message
+  once the subscription has successfully subscribed.
+
+  After this message events will be sent to the subscriber, in batches, as
+  `{:events, events}` where events is a collection of `EventStore.RecordedEvent`
+  structs.
+
+  ## Example
+
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, "example", self())
+
+      # wait for the subscription confirmation
+      receive do
+        {:subscribed, ^subscription} ->
+          IO.puts "Successfully subscribed to stream: " <> inspect(stream_uuid)
+      end
+
+      receive do
+        {:events, events} ->
+          IO.puts "Received events: " <> inspect(events)
+
+          # acknowledge receipt
+          EventStore.ack(subscription, events)
+      end
+
   """
   @spec subscribe_to_stream(String.t, String.t, pid, keyword) :: {:ok, subscription :: pid}
     | {:error, :subscription_already_exists}
@@ -280,6 +308,25 @@ defmodule EventStore do
         to the subscriber.
 
   Returns `{:ok, subscription}` when subscription succeeds.
+
+  ## Example
+
+      {:ok, subscription} = EventStore.subscribe_to_all_streams("all_subscription", self())
+
+      # wait for the subscription confirmation
+      receive do
+        {:subscribed, ^subscription} ->
+          IO.puts "Successfully subscribed to all streams"
+      end
+
+      receive do
+        {:events, events} ->
+          IO.puts "Received events: " <> inspect(events)
+
+          # acknowledge receipt
+          EventStore.ack(subscription, events)
+      end
+
   """
   @spec subscribe_to_all_streams(String.t, pid, keyword) :: {:ok, subscription :: pid}
     | {:error, :subscription_already_exists}

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -20,7 +20,8 @@ defmodule EventStore.Subscriptions.Subscription do
     subscriber: nil,
     subscription: nil,
     subscription_opts: [],
-    postgrex_config: nil
+    postgrex_config: nil,
+    retry_interval: nil
   ]
 
   def start_link(postgrex_config, stream_uuid, subscription_name, subscriber, subscription_opts, opts \\ []) do
@@ -30,7 +31,8 @@ defmodule EventStore.Subscriptions.Subscription do
       subscriber: subscriber,
       subscription: StreamSubscription.new(),
       subscription_opts: subscription_opts,
-      postgrex_config: postgrex_config
+      postgrex_config: postgrex_config,
+      retry_interval: subscription_retry_interval()
     }, opts)
   end
 
@@ -70,26 +72,29 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   @doc false
-  def init(%Subscription{subscriber: subscriber, postgrex_config: postgrex_config} = state) do
+  def init(%Subscription{subscriber: subscriber} = state) do
     Process.link(subscriber)
-
-    # Each subscription has its own connection to the database to enforce locking
-    {:ok, conn} = Postgrex.start_link(postgrex_config)
 
     send(self(), :subscribe_to_stream)
 
-    {:ok, %Subscription{state | conn: conn}}
+    {:ok, state}
   end
 
   def handle_info(:subscribe_to_stream, %Subscription{} = state) do
     %Subscription{
-      conn: conn,
+      postgrex_config: postgrex_config,
       stream_uuid: stream_uuid,
       subscription_name: subscription_name,
       subscriber: subscriber,
       subscription: subscription,
       subscription_opts: opts
     } = state
+
+    # Each subscription has its own connection to the database to acquire an
+    # advisory lock to ensure only one subscription
+    {:ok, conn} = Postgrex.start_link(postgrex_config)
+
+    state = %Subscription{state | conn: conn}
 
     subscription = StreamSubscription.subscribe(subscription, conn, stream_uuid, subscription_name, subscriber, opts)
 
@@ -142,40 +147,49 @@ defmodule EventStore.Subscriptions.Subscription do
   defp apply_subscription_to_state(%StreamSubscription{} = subscription, %Subscription{} = state) do
     state = %Subscription{state | subscription: subscription}
 
-    :ok = handle_subscription_state(state)
-
-    state
+    handle_subscription_state(state)
   end
 
   defp handle_subscription_state(%Subscription{subscription: %{state: :initial}} = state) do
-    retry_interval = subscription_retry_interval()
+    %Subscription{retry_interval: retry_interval} = state
 
     _ = Logger.debug(fn -> describe(state) <> " failed to subscribe, will retry in #{retry_interval}ms" end)
 
     Process.send_after(self(), :subscribe_to_stream, retry_interval)
-    :ok
+
+    close_database_connection(state)
   end
 
   defp handle_subscription_state(%Subscription{subscription: %{state: :subscribe_to_events}} = state) do
     _ = Logger.debug(fn -> describe(state) <> " subscribing to events" end)
 
     GenServer.cast(self(), :subscribe_to_events)
+
+    state
   end
 
   defp handle_subscription_state(%Subscription{subscription: %{state: :request_catch_up}} = state) do
     _ = Logger.debug(fn -> describe(state) <> " requesting catch-up" end)
 
     GenServer.cast(self(), :catch_up)
+
+    state
   end
 
   defp handle_subscription_state(%Subscription{subscription: %{state: :max_capacity}} = state) do
     _ = Logger.warn(fn -> describe(state) <> " has reached max capacity, events will be ignored until it has caught up" end)
 
-    :ok
+    state
+  end
+
+  defp handle_subscription_state(%Subscription{subscription: %{state: :unsubscribed}} = state) do
+    _ = Logger.warn(fn -> describe(state) <> " has unsubscribed" end)
+
+    close_database_connection(state)
   end
 
   # no-op for all other subscription states
-  defp handle_subscription_state(_state), do: :ok
+  defp handle_subscription_state(state), do: state
 
   defp subscribe_to_events(%Subscription{stream_uuid: stream_uuid}) do
     Registration.subscribe(stream_uuid)
@@ -184,8 +198,13 @@ defmodule EventStore.Subscriptions.Subscription do
   # notify the subscriber that this subscription has successfully subscribed to events
   defp notify_subscribed(%Subscription{subscriber: subscriber}) do
     send(subscriber, {:subscribed, self()})
-
     :ok
+  end
+
+  defp close_database_connection(%Subscription{conn: conn} = state) do
+    :ok = GenServer.stop(conn)
+
+    %Subscription{state | conn: nil}
   end
 
   # Get the delay between subscription attempts, in milliseconds, from app
@@ -193,8 +212,13 @@ defmodule EventStore.Subscriptions.Subscription do
   # second.
   defp subscription_retry_interval do
     case Application.get_env(:eventstore, :subscription_retry_interval) do
-      interval when is_integer(interval) and interval > 0 -> min(interval, 1_000)
-      _ -> 60_000
+      interval when is_integer(interval) and interval > 0 ->
+        # ensure interval is no less than one second
+        min(interval, 1_000)
+
+      _ ->
+        # default to 60s
+        60_000
     end
   end
 

--- a/test/subscriptions/subscription_back_pressure_test.exs
+++ b/test/subscriptions/subscription_back_pressure_test.exs
@@ -1,7 +1,7 @@
 defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
   use EventStore.StorageCase
 
-  alias EventStore.{EventFactory,Subscriptions,Wait}
+  alias EventStore.{EventFactory, Subscriptions}
   alias EventStore.Streams.Stream
   alias EventStore.Subscriptions.Subscription
 
@@ -80,16 +80,10 @@ defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
 
   # subscribe to all streams and wait for the subscription to be subscribed
   defp subscribe_to_all_streams(subscription_name, subscriber, opts) do
-    with {:ok, subscription} <- Subscriptions.subscribe_to_all_streams(subscription_name, subscriber, opts) do
-      wait_until_subscribed(subscription)
+    {:ok, subscription} = Subscriptions.subscribe_to_all_streams(subscription_name, subscriber, opts)
 
-      {:ok, subscription}
-    end
-  end
+    assert_receive {:subscribed, ^subscription}
 
-  defp wait_until_subscribed(subscription) do
-    Wait.until(fn ->
-      assert Subscription.subscribed?(subscription)
-    end)
+    {:ok, subscription}
   end
 end

--- a/test/support/collecting_subscriber.ex
+++ b/test/support/collecting_subscriber.ex
@@ -4,43 +4,53 @@ defmodule EventStore.Support.CollectingSubscriber do
   alias EventStore.Subscriptions
   alias EventStore.Subscriptions.Subscription
 
-  def start_link(subscription_name) do
-    GenServer.start_link(__MODULE__, subscription_name)
+  def start_link(subscription_name, notify_subscribed) do
+    GenServer.start_link(__MODULE__, [subscription_name, notify_subscribed])
   end
 
   def received_events(subscriber) do
     GenServer.call(subscriber, {:received_events})
   end
 
-  def subscribed?(subscriber) do
-    GenServer.call(subscriber, {:subscribed?})
-  end
-
   def unsubscribe(subscriber) do
     GenServer.call(subscriber, {:unsubscribe})
   end
 
-  def init(subscription_name) do
+  def init([subscription_name, notify_subscribed]) do
     {:ok, subscription} = Subscriptions.subscribe_to_all_streams(subscription_name, self())
 
-    {:ok, %{events: [], subscription: subscription, subscription_name: subscription_name}}
+    state = %{
+      events: [],
+      subscription: subscription,
+      subscription_name: subscription_name,
+      notify_subscribed: notify_subscribed
+    }
+
+    {:ok, state}
   end
 
   def handle_call({:received_events}, _from, %{events: events} = state) do
     {:reply, events, state}
   end
 
-  def handle_call({:subscribed?}, _from, %{subscription: subscription} = state) do
-    reply = Subscription.subscribed?(subscription)
-    {:reply, reply, state}
-  end
-
   def handle_call({:unsubscribe}, _from, %{subscription_name: subscription_name} = state) do
     Subscriptions.unsubscribe_from_all_streams(subscription_name)
+
     {:reply, :ok, state}
   end
 
-  def handle_info({:events, received_events}, %{events: events, subscription: subscription} = state) do
+  def handle_info(
+        {:subscribed, subscription},
+        %{subscription: subscription, notify_subscribed: notify_subscribed} = state
+      ) do
+    send(notify_subscribed, {:subscribed, self()})
+
+    {:noreply, state}
+  end
+
+  def handle_info({:events, received_events}, state) do
+    %{events: events, subscription: subscription} = state
+
     Subscription.ack(subscription, received_events)
 
     {:noreply, %{state | events: events ++ received_events}}

--- a/test/support/subscriber.ex
+++ b/test/support/subscriber.ex
@@ -17,9 +17,16 @@ defmodule EventStore.Subscriber do
     {:ok, %{receiver: receiver, events: []}}
   end
 
-  def handle_info({:events, events}, %{receiver: receiver} = state) do
-    # send events to receiving process
-    send(receiver, {:events, events})
+  def handle_info({:subscribed, subscription} = message, %{receiver: receiver} = state) do
+    # send message to receiving process
+    send(receiver, message)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:events, events} = message, %{receiver: receiver} = state) do
+    # send message to receiving process
+    send(receiver, message)
 
     {:noreply, %{state | events: state.events ++ events}}
   end


### PR DESCRIPTION
Once the subscription has successfully subscribed to the stream it will send the subscriber a `{:subscribed, subscription}` message.

This indicates the subscription succeeded and you will begin receiving events.