### PR TITLE
Transient subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use PostgreSQL's `NOTIFY` / `LISTEN` for event pub/sub ([#100](https://github.com/commanded/eventstore/pull/100)).
 - Link existing events to another stream ([#103](https://github.com/commanded/eventstore/pull/103)).
 - Subscription notification message once successfully subscribed ([#104](https://github.com/commanded/eventstore/pull/104)).
+- Transient subscriptions ([#105](https://github.com/commanded/eventstore/pull/105)).
 
 ## v0.13.2
 

--- a/guides/Cluster.md
+++ b/guides/Cluster.md
@@ -1,4 +1,4 @@
-# Cluster
+# Running on a cluster of nodes
 
 EventStore supports running on multiple nodes as either a [distributed Erlang](http://erlang.org/doc/reference_manual/distributed.html) cluster or as multiple single instance nodes.
 

--- a/guides/Event Serialization.md
+++ b/guides/Event Serialization.md
@@ -1,6 +1,6 @@
 # Event serialization
 
-The default serialization of event data and metadata uses Erlang's [external term format](http://erlang.org/doc/apps/erts/erl_ext_dist.html). This is not a recommended serialization format for production usage.
+The default serialization of event data and metadata uses Erlang's [external term format](http://erlang.org/doc/apps/erts/erl_ext_dist.html). This is not a recommended serialization format for production usage as backwards compatibility is only guaranteed going back at least two major releases.
 
 You must implement the `EventStore.Serializer` behaviour to provide your preferred serialization format.
 

--- a/lib/event_store/notifications/stream_broadcaster.ex
+++ b/lib/event_store/notifications/stream_broadcaster.ex
@@ -25,6 +25,6 @@ defmodule EventStore.Notifications.StreamBroadcaster do
   end
 
   defp broadcast(stream_uuid, events) do
-    Registration.broadcast(stream_uuid, {:notify_events, events})
+    Registration.broadcast(stream_uuid, {:events, events})
   end
 end

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -26,8 +26,6 @@ defmodule EventStore.Subscriptions do
   end
 
   defp do_subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts) do
-    _ = Logger.debug(fn -> "Subscribing to stream #{inspect stream_uuid} named #{inspect subscription_name} with opts: #{inspect opts}" end)
-
     case Subscriptions.Supervisor.subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts) do
       {:ok, subscription} -> {:ok, subscription}
       {:error, {:already_started, _subscription}} -> {:error, :subscription_already_exists}

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -36,10 +36,6 @@ defmodule EventStore.Subscriptions.Subscription do
     }, opts)
   end
 
-  def notify_events(subscription, events) when is_list(events) do
-    send(subscription, {:notify_events, events})
-  end
-
   @doc """
   Confirm receipt of the given event by its `stream_version`
   """
@@ -101,7 +97,7 @@ defmodule EventStore.Subscriptions.Subscription do
     {:noreply, apply_subscription_to_state(subscription, state)}
   end
 
-  def handle_info({:notify_events, events}, %Subscription{subscription: subscription} = state) do
+  def handle_info({:events, events}, %Subscription{subscription: subscription} = state) do
     _ = Logger.debug(fn -> describe(state) <> " received #{length(events)} events(s)" end)
 
     subscription = StreamSubscription.notify_events(subscription, events)

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -254,7 +254,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(received_events, :data) == pluck(events, :data)
 
       # notify duplicate events, should be ignored
-      Subscription.notify_events(subscription, recorded_events)
+      send(subscription, {:events, recorded_events})
 
       refute_receive {:events, _events}
     end

--- a/test/subscriptions/subscription_back_pressure_test.exs
+++ b/test/subscriptions/subscription_back_pressure_test.exs
@@ -49,7 +49,7 @@ defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
 
       # notify the subscription with unexpected events
       unexpected_events = EventFactory.create_recorded_events(5, stream1_uuid, 999)
-      Subscription.notify_events(subscription, unexpected_events)
+      send(subscription, {:events, unexpected_events})
 
       append_to_stream(stream3_uuid, 3)
       append_to_stream(stream4_uuid, 3)


### PR DESCRIPTION
Add `EventStore.subscribe/1` to create a transient subscription for events appended to a given stream.