### PR TITLE
Advisory locks use single database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - Link existing events to another stream ([#103](https://github.com/commanded/eventstore/pull/103)).
 - Subscription notification message once successfully subscribed ([#104](https://github.com/commanded/eventstore/pull/104)).
 - Transient subscriptions ([#105](https://github.com/commanded/eventstore/pull/105)).
-- Use a single PostgreSQL connection for all subscriptions ([#106](https://github.com/commanded/eventstore/pull/106)).
 - Transient subscription event mapping function ([#108](https://github.com/commanded/eventstore/pull/108)).
 
 ## v0.13.2

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -124,22 +124,11 @@ defmodule EventStore.Config do
           :pool_overflow
         ]
     )
+    |> Keyword.put(:backoff_type, :exp)
     |> Keyword.put(:name, EventStore.Postgrex)
   end
 
-  def listener_postgrex_opts(config) do
-    sync_connect_postgrex_opts(config)
-  end
-
-  def reader_postgrex_opts(config) do
-    sync_connect_postgrex_opts(config)
-  end
-
-  def subscription_postgrex_opts(config) do
-    sync_connect_postgrex_opts(config)
-  end
-
-  defp sync_connect_postgrex_opts(config) do
+  def sync_connect_postgrex_opts(config) do
     config
     |> default_postgrex_opts()
     |> Keyword.put(:backoff_type, :stop)

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -40,23 +40,25 @@ defmodule EventStore.Notifications.Supervisor do
   end
 
   def init(config) do
+    postgrex_config = Config.sync_connect_postgrex_opts(config)
+
     Supervisor.init(
       [
         Supervisor.child_spec(
           {MonitoredServer, [
-            {Postgrex.Notifications, :start_link, [Config.listener_postgrex_opts(config)]},
+            {Postgrex.Notifications, :start_link, [postgrex_config]},
             [
               after_restart: &Listener.reconnect/0,
               after_exit: &Listener.disconnect/0,
-              name: EventStore.Notifications.Listener.Postgrex
+              name: Listener.Postgrex
             ]
           ]},
           id: Listener.Postgrex
         ),
         Supervisor.child_spec(
           {MonitoredServer, [
-            {Postgrex, :start_link, [Config.reader_postgrex_opts(config)]},
-            [name: EventStore.Notifications.Reader.Postgrex]
+            {Postgrex, :start_link, [postgrex_config]},
+            [name: Reader.Postgrex]
           ]},
           id: Reader.Postgrex
         ),

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -4,6 +4,7 @@ defmodule EventStore.Subscriptions.SubscriptionState do
   defstruct conn: nil,
             catch_up_pid: nil,
             stream_uuid: nil,
+            start_from: nil,
             subscription_name: nil,
             subscriber: nil,
             subscription_id: nil,

--- a/lib/event_store/subscriptions/supervisor.ex
+++ b/lib/event_store/subscriptions/supervisor.ex
@@ -36,18 +36,6 @@ defmodule EventStore.Subscriptions.Supervisor do
     end
   end
 
-  def reconnect do
-    for {_id, subscription, _type, _modules} <- Supervisor.which_children(__MODULE__) do
-      Subscription.reconnect(subscription)
-    end
-  end
-
-  def disconnect do
-    for {_id, subscription, _type, _modules} <- Supervisor.which_children(__MODULE__) do
-      Subscription.disconnect(subscription)
-    end
-  end
-
   def init(args) do
     children = [
       worker(Subscription, args, restart: :temporary)

--- a/test/advisory_locks_test.exs
+++ b/test/advisory_locks_test.exs
@@ -2,50 +2,46 @@ defmodule EventStore.AdvisoryLocksTest do
   use EventStore.StorageCase
 
   alias EventStore.{AdvisoryLocks, Config, ProcessHelper}
+  alias EventStore.Storage
 
   setup do
     postgrex_config = Config.parsed() |> Config.default_postgrex_opts()
 
-    {:ok, conn1} = Postgrex.start_link(postgrex_config)
-    {:ok, conn2} = Postgrex.start_link(postgrex_config)
+    {:ok, conn} = Postgrex.start_link(postgrex_config)
 
     on_exit fn ->
-      ProcessHelper.shutdown(conn1)
-      ProcessHelper.shutdown(conn2)
+      ProcessHelper.shutdown(conn)
     end
 
     [
-      conn1: conn1,
-      conn2: conn2
+      conn: conn
     ]
   end
 
   describe "acquire lock" do
-    test "should acquire lock when available", %{conn1: conn1} do
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
+    test "should acquire lock when available" do
+      assert :ok = AdvisoryLocks.try_advisory_lock(1)
     end
 
-    test "should acquire lock when same process already has lock", %{conn1: conn1} do
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
+    test "should acquire lock when same process already has lock" do
+      assert :ok = AdvisoryLocks.try_advisory_lock(1)
+      assert :ok = AdvisoryLocks.try_advisory_lock(1)
+      assert :ok = AdvisoryLocks.try_advisory_lock(1)
     end
 
-    test "should fail to acquire lock when already taken", context do
-      %{conn1: conn1, conn2: conn2} = context
+    test "should fail to acquire lock when already taken", %{conn: conn} do
+      :ok = Storage.Lock.try_acquire_exclusive_lock(conn, 1)
 
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
-      assert {:error, :lock_already_taken} = AdvisoryLocks.try_advisory_lock(conn2, 1)
+      assert {:error, :lock_already_taken} = AdvisoryLocks.try_advisory_lock(1)
     end
   end
 
   describe "release lock" do
-    test "should release lock when process terminates", context do
-      %{conn1: conn1, conn2: conn2} = context
-
+    test "should release lock when process terminates", %{conn: conn} do
       reply_to = self()
+
       pid = spawn_link(fn ->
-        assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
+        assert :ok = AdvisoryLocks.try_advisory_lock(1)
 
         send(reply_to, :lock_acquired)
 
@@ -54,28 +50,59 @@ defmodule EventStore.AdvisoryLocksTest do
       end)
 
       assert_receive :lock_acquired
-      assert {:error, :lock_already_taken} = AdvisoryLocks.try_advisory_lock(conn2, 1)
+      assert {:error, :lock_already_taken} = Storage.Lock.try_acquire_exclusive_lock(conn, 1)
 
       ProcessHelper.shutdown(pid)
 
       # wait for lock to be released after process terminates
       :timer.sleep 100
 
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn2, 1)
+      assert :ok = Storage.Lock.try_acquire_exclusive_lock(conn, 1)
+    end
+  end
+
+  describe "disconnect" do
+    test "should execute `lock_released` callback function" do
+      reply_to = self()
+
+      assert :ok = AdvisoryLocks.try_advisory_lock(1, lock_released: fn ->
+        send(reply_to, :lock_released)
+      end)
+
+      AdvisoryLocks.disconnect()
+
+      assert_receive(:lock_released)
+    end
+  end
+
+  describe "reconnect" do
+    test "should execute `lock_reacquired` callback function when reacquired" do
+      reply_to = self()
+
+      assert :ok = AdvisoryLocks.try_advisory_lock(1, lock_reacquired: fn ->
+        send(reply_to, :lock_reacquired)
+      end)
+
+      :ok = AdvisoryLocks.disconnect()
+
+      assert :ok = AdvisoryLocks.reconnect()
+      assert_receive(:lock_reacquired)
     end
 
-    test "should forget locks when `conn` terminates", context do
-      %{conn1: conn1, conn2: conn2} = context
+    test "should not execute `lock_reacquired` callback function when cannot reacquire", %{conn: conn} do
+      reply_to = self()
 
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn1, 1)
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn2, 2)
+      assert :ok = AdvisoryLocks.try_advisory_lock(1, lock_reacquired: fn ->
+        send(reply_to, :lock_reacquired)
+      end)
 
-      # shutdown connection
-      ProcessHelper.shutdown(conn1)
+      :ok = AdvisoryLocks.disconnect()
 
-      :timer.sleep 100
+      :ok = Storage.Lock.unlock(AdvisoryLocks.Postgrex, 1)
+      :ok = Storage.Lock.try_acquire_exclusive_lock(conn, 1)
 
-      assert :ok = AdvisoryLocks.try_advisory_lock(conn2, 1)
+      assert :ok = AdvisoryLocks.reconnect()
+      refute_receive(:lock_reacquired)
     end
   end
 end

--- a/test/manual/long_running_subscription.exs
+++ b/test/manual/long_running_subscription.exs
@@ -18,7 +18,7 @@ defmodule LoggingSubscriber do
     {:ok, subscribe_to_stream(stream_uuid)}
   end
 
-  def handle_info({:subscribed, subscription} = message, subscription) do
+  def handle_info({:subscribed, subscription}, subscription) do
     Logger.debug(fn -> "Subscribed to stream" end)
 
     {:noreply, subscription}
@@ -75,6 +75,6 @@ end
 
 stream_uuid = UUID.uuid4()
 
-{:ok, subscriber1} = LoggingSubscriber.start_link("$all")
-{:ok, subscriber2} = LoggingSubscriber.start_link(stream_uuid)
-{:ok, appender} = IntervalAppender.start_link(stream_uuid)
+{:ok, _subscriber1} = LoggingSubscriber.start_link("$all")
+{:ok, _subscriber2} = LoggingSubscriber.start_link(stream_uuid)
+{:ok, _appender} = IntervalAppender.start_link(stream_uuid)

--- a/test/notifications/notify_events_test.exs
+++ b/test/notifications/notify_events_test.exs
@@ -8,7 +8,7 @@ defmodule EventStore.Notifications.NotifyEventsTest do
   setup do
     listener_opts =
       Config.parsed()
-      |> Config.listener_postgrex_opts()
+      |> Config.sync_connect_postgrex_opts()
       |> Keyword.put(:name, __MODULE__)
 
     {:ok, conn} = Postgrex.Notifications.start_link(listener_opts)


### PR DESCRIPTION
Use a single PostgreSQL database connection to acquire all advisory locks. Subscriptions attempt to acquire a lock to ensure only a single subscriber runs, regardless of how many nodes EventStore runs on.

Subscriptions are disconnected whenever the lock is released, due to a loss of database connectivity. When the connection is restored an attempt is made to reacquire the locks, if successful the subscription resumes.

This pull requests partially reverts the changes made in #106 to use a single connection for all subscriptions. As this became a bottleneck and caused issues when there were many active subscriptions. Instead, the subscriptions make use of the shared database connection pool for their database operations and another single connection is used to hold the advisory locks, as described above.