### PR TITLE
Turn EventStore mix tasks into generic tasks for use with Distillery

### DIFF
--- a/lib/event_store/tasks/create.ex
+++ b/lib/event_store/tasks/create.ex
@@ -1,0 +1,37 @@
+defmodule EventStore.Tasks.Create do
+  @moduledoc """
+  Task to create the EventStore
+  """
+
+  alias EventStore.Storage.Database
+  import EventStore.Tasks.Output
+
+  @doc """
+  Runs task
+
+  ## Parameters
+  - config: the parsed EventStore config
+
+  ## Opts
+  - is_mix: set to `true` if running as part of a Mix task
+  - quiet: set to `true` to silence output
+
+  """
+  def exec(config, opts) do
+    opts = Keyword.merge([is_mix: false, quiet: false], opts)
+
+    case Database.create(config) do
+      :ok ->
+        write_info("The EventStore database has been created.", opts)
+
+      {:error, :already_up} ->
+        write_info("The EventStore database already exists.", opts)
+
+      {:error, term} ->
+        raise_msg(
+          "The EventStore database couldn't be created, reason given: #{inspect(term)}.",
+          opts
+        )
+    end
+  end
+end

--- a/lib/event_store/tasks/drop.ex
+++ b/lib/event_store/tasks/drop.ex
@@ -1,0 +1,37 @@
+defmodule EventStore.Tasks.Drop do
+  @moduledoc """
+  Task to drop the EventStore database.
+  """
+
+  alias EventStore.Storage.Database
+  import EventStore.Tasks.Output
+
+  @doc """
+  Runs task
+
+  ## Parameters
+  - config: the parsed EventStore config
+
+  ## Opts
+  - is_mix: set to `true` if running as part of a Mix task
+  - quiet: set to `true` to silence output
+
+  """
+  def exec(config, opts) do
+    opts = Keyword.merge([is_mix: false, quiet: false], opts)
+
+    case Database.drop(config) do
+      :ok ->
+        write_info("The EventStore database has been dropped.", opts)
+
+      {:error, :already_down} ->
+        write_info("The EventStore database has already been dropped.", opts)
+
+      {:error, term} ->
+        raise_msg(
+          "The EventStore database couldn't be dropped, reason given: #{inspect(term)}.",
+          opts
+        )
+    end
+  end
+end

--- a/lib/event_store/tasks/init.ex
+++ b/lib/event_store/tasks/init.ex
@@ -1,0 +1,46 @@
+defmodule EventStore.Tasks.Init do
+  @moduledoc """
+  Task to initalize the EventStore database
+  """
+
+  import EventStore.Tasks.Output
+  alias EventStore.Storage.Initializer
+
+  @is_events_table_exists """
+    SELECT EXISTS (
+      SELECT 1
+      FROM   information_schema.tables
+      WHERE  table_schema = 'public'
+      AND    table_name = 'events'
+    )
+  """
+
+  @doc """
+  Runs task
+
+  ## Parameters
+  - config: the parsed EventStore config
+
+  ## Opts
+  - is_mix: set to `true` if running as part of a Mix task
+  - quiet: set to `true` to silence output
+
+  """
+  def exec(config, opts) do
+    opts = Keyword.merge([is_mix: false, quiet: false], opts)
+
+    {:ok, conn} = Postgrex.start_link(config)
+
+    conn_opts = [pool: DBConnection.Poolboy]
+
+    Postgrex.query!(conn, @is_events_table_exists, [], conn_opts)
+    |> case do
+      %{rows: [[true]]} ->
+        write_info("The EventStore database has already been initialized.", opts)
+
+      %{rows: [[false]]} ->
+        Initializer.run!(conn, conn_opts)
+        write_info("The EventStore database has been initialized.", opts)
+    end
+  end
+end

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -1,0 +1,101 @@
+defmodule EventStore.Tasks.Migrate do
+  @moduledoc """
+    Task to migrate EventStore
+  """
+
+  alias EventStore.Storage.Database
+  import EventStore.Tasks.Output
+
+  @available_migrations [
+    "0.13.0",
+    "0.14.0"
+  ]
+
+  @doc """
+  Run task
+
+  ## Parameters
+  - config: the parsed EventStore config
+
+  ## Opts
+  - is_mix: set to `true` if running as part of a Mix task
+  - quiet: set to `true` to silence output
+
+  """
+  def exec(config, opts) do
+    opts = Keyword.merge([is_mix: false, quiet: false], opts)
+
+    migrations =
+      case event_store_schema_version(config) do
+        [] ->
+          # run all migrations
+          @available_migrations
+
+        [event_store_version | _] ->
+          # only run newer migrations
+          @available_migrations
+          |> Enum.filter(fn migration_version ->
+            migration_version |> Version.parse!() |> Version.compare(event_store_version) == :gt
+          end)
+      end
+
+    migrate(config, opts, migrations)
+  end
+
+  defp migrate(_config, opts, []) do
+    write_info("The EventStore database is already migrated.", opts)
+  end
+
+  defp migrate(config, opts, migrations) do
+    for migration <- migrations do
+      write_info("Running migration v#{migration}...", opts)
+
+      path = Application.app_dir(:eventstore, "priv/event_store/migrations/v#{migration}.sql")
+      script = File.read!(path)
+
+      case Database.migrate(config, script) do
+        :ok ->
+          :ok
+
+        {:error, term} ->
+          raise_msg(
+            "The EventStore database couldn't be migrated, reason given: #{inspect(term)}.",
+            opts
+          )
+      end
+    end
+
+    write_info("The EventStore database has been migrated.", opts)
+  end
+
+  defp event_store_schema_version(config) do
+    config
+    |> query_schema_migrations()
+    |> Enum.sort(fn left, right ->
+      case Version.compare(left, right) do
+        :gt -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp query_schema_migrations(config) do
+    with {:ok, conn} <- Postgrex.start_link(config) do
+      conn
+      |> Postgrex.query!(
+        "SELECT major_version, minor_version, patch_version FROM schema_migrations",
+        [],
+        pool: DBConnection.Poolboy
+      )
+      |> handle_response()
+    end
+  end
+
+  defp handle_response(%Postgrex.Result{num_rows: 0}), do: []
+
+  defp handle_response(%Postgrex.Result{rows: rows}) do
+    Enum.map(rows, fn [major_version, minor_version, patch_version] ->
+      Version.parse!("#{major_version}.#{minor_version}.#{patch_version}")
+    end)
+  end
+end

--- a/lib/event_store/tasks/output.ex
+++ b/lib/event_store/tasks/output.ex
@@ -1,0 +1,31 @@
+defmodule EventStore.Tasks.Output do
+  @moduledoc false
+
+  def write_info(msg, opts) do
+    unless opts[:quiet] do
+      info(msg, opts[:is_mix])
+    end
+  end
+
+  defp info(msg, true) do
+    Mix.shell().info(msg)
+  end
+
+  defp info(msg, _) do
+    IO.puts(msg)
+  end
+
+  def raise_msg(msg, opts) do
+    unless opts[:quiet] do
+      do_raise(msg, opts[:is_mix])
+    end
+  end
+
+  defp do_raise(msg, true) do
+    Mix.raise(msg)
+  end
+
+  defp do_raise(msg, _) do
+    raise msg
+  end
+end

--- a/lib/mix/tasks/event_store.create.ex
+++ b/lib/mix/tasks/event_store.create.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.EventStore.Create do
   use Mix.Task
 
   alias EventStore.Config
-  alias EventStore.Storage.Database
+  alias EventStore.Tasks.Create
 
   @shortdoc "Create the database for the EventStore"
 
@@ -26,25 +26,8 @@ defmodule Mix.Tasks.EventStore.Create do
     config = Config.parsed()
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])
 
-    create_database(config, opts)
+    Create.exec(config, Keyword.put(opts, :is_mix, true))
 
-    Mix.Task.reenable "event_store.create"
-  end
-
-  defp create_database(config, opts) do
-    case Database.create(config) do
-      :ok ->
-        unless opts[:quiet] do
-          Mix.shell.info "The EventStore database has been created."
-        end
-
-      {:error, :already_up} ->
-        unless opts[:quiet] do
-          Mix.shell.info "The EventStore database already exists."
-        end
-
-      {:error, term} ->
-        Mix.raise "The EventStore database couldn't be created, reason given: #{inspect term}."
-    end
+    Mix.Task.reenable("event_store.create")
   end
 end

--- a/lib/mix/tasks/event_store.drop.ex
+++ b/lib/mix/tasks/event_store.drop.ex
@@ -11,7 +11,6 @@ defmodule Mix.Tasks.EventStore.Drop do
   use Mix.Task
 
   alias EventStore.Config
-  alias EventStore.Storage.Database
 
   @shortdoc "Drop the database for the EventStore"
 
@@ -19,20 +18,13 @@ defmodule Mix.Tasks.EventStore.Drop do
   def run(_args) do
     config = Config.parsed()
 
-    if skip_safety_warnings?() or Mix.shell.yes?("Are you sure you want to drop the EventStore database?") do
-      drop_database(config)
+    if skip_safety_warnings?() or
+         Mix.shell().yes?("Are you sure you want to drop the EventStore database?") do
+      EventStore.Tasks.Drop.exec(config, is_mix: true)
     end
   end
 
   defp skip_safety_warnings? do
-    Mix.Project.config[:start_permanent] != true
-  end
-
-  defp drop_database(config) do
-    case Database.drop(config) do
-      :ok -> Mix.shell.info "The EventStore database has been dropped."
-      {:error, :already_down} -> Mix.shell.info "The EventStore database has already been dropped."
-      {:error, term} -> Mix.raise "The EventStore database couldn't be dropped, reason given: #{inspect term}."
-    end
+    Mix.Project.config()[:start_permanent] != true
   end
 end

--- a/lib/mix/tasks/event_store.migrate.ex
+++ b/lib/mix/tasks/event_store.migrate.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.EventStore.Migrate do
   use Mix.Task
 
   alias EventStore.Config
-  alias EventStore.Storage.Database
+  alias EventStore.Tasks.Migrate
 
   @shortdoc "Migrate an existing EventStore database"
 
@@ -26,87 +26,8 @@ defmodule Mix.Tasks.EventStore.Migrate do
     config = Config.parsed()
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])
 
-    migrate_database(config, opts)
+    Migrate.exec(config, Keyword.put(opts, :is_mix, true))
 
     Mix.Task.reenable("event_store.migrate")
-  end
-
-  @available_migrations [
-    "0.13.0",
-    "0.14.0"
-  ]
-
-  defp migrate_database(config, opts) do
-    migrations =
-      case event_store_schema_version(config) do
-        [] ->
-          # run all migrations
-          @available_migrations
-
-        [event_store_version | _] ->
-          # only run newer migrations
-          @available_migrations
-          |> Enum.filter(fn migration_version ->
-            migration_version |> Version.parse!() |> Version.compare(event_store_version) == :gt
-          end)
-      end
-
-    migrate(config, opts, migrations)
-  end
-
-  defp migrate(_config, opts, []) do
-    unless opts[:quiet], do: Mix.shell().info("The EventStore database is already migrated.")
-  end
-
-  defp migrate(config, opts, migrations) do
-    for migration <- migrations do
-      unless opts[:quiet], do: Mix.shell().info("Running migration v#{migration}...")
-
-      path = Application.app_dir(:eventstore, "priv/event_store/migrations/v#{migration}.sql")
-      script = File.read!(path)
-
-      case Database.migrate(config, script) do
-        :ok ->
-          :ok
-
-        {:error, term} ->
-          Mix.raise(
-            "The EventStore database couldn't be migrated, reason given: #{inspect(term)}."
-          )
-      end
-    end
-
-    unless opts[:quiet], do: Mix.shell().info("The EventStore database has been migrated.")
-  end
-
-  defp event_store_schema_version(config) do
-    config
-    |> query_schema_migrations()
-    |> Enum.sort(fn left, right ->
-      case Version.compare(left, right) do
-        :gt -> true
-        _ -> false
-      end
-    end)
-  end
-
-  defp query_schema_migrations(config) do
-    with {:ok, conn} <- Postgrex.start_link(config) do
-      conn
-      |> Postgrex.query!(
-        "SELECT major_version, minor_version, patch_version FROM schema_migrations",
-        [],
-        pool: DBConnection.Poolboy
-      )
-      |> handle_response()
-    end
-  end
-
-  defp handle_response(%Postgrex.Result{num_rows: 0}), do: []
-
-  defp handle_response(%Postgrex.Result{rows: rows}) do
-    Enum.map(rows, fn [major_version, minor_version, patch_version] ->
-      Version.parse!("#{major_version}.#{minor_version}.#{patch_version}")
-    end)
   end
 end


### PR DESCRIPTION
Intentionally did not try and address using Ecto for migrations, as I
did not want to introduce the dependency at this time. This simply moves
the logic to eventstore/tasks and removes any Mix dependencies.

Fixes #87 