### PR TITLE
Initial proposal for event filtering

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -291,6 +291,8 @@ defmodule EventStore do
       Use the `$all` identifier to subscribe to events from all streams.
 
     - `opts` is an optional map providing additional subscription configuration:
+      - `selector` to define a function to filter each event, i.e. returns
+        only those elements for which fun returns a truthy value
       - `mapper` to define a function to map each recorded event before sending
         to the subscriber.
 
@@ -319,7 +321,11 @@ defmodule EventStore do
       end
 
   """
-  @spec subscribe(String.t(), mapper: (RecordedEvent.t() -> any())) :: :ok | {:error, term}
+  @spec subscribe(
+          String.t(),
+          selector: (RecordedEvent.t() -> any()),
+          mapper: (RecordedEvent.t() -> any())
+        ) :: :ok | {:error, term}
 
   def subscribe(stream_uuid, opts \\ [])
 
@@ -345,8 +351,11 @@ defmodule EventStore do
           - `:current` for any new events appended to the stream after the
             subscription has been created.
           - any positive integer for a stream version to receive events after.
+      - `selector` to define a function to filter each event, i.e. returns
+        only those elements for which fun returns a truthy value
       - `mapper` to define a function to map each recorded event before sending
         to the subscriber.
+      
 
   The subscription will resume from the last acknowledged event if it already
   exists. It will ignore the `start_from` argument in this case.
@@ -416,6 +425,8 @@ defmodule EventStore do
             subscription has been created.
           - any positive integer for an event id to receive events after that
             exact event.
+      - `selector` to define a function to filter each event, i.e. returns
+        only those elements for which fun returns a truthy value
       - `mapper` to define a function to map each recorded event before sending
         to the subscriber.
 

--- a/lib/event_store/registration/distributed_registry.ex
+++ b/lib/event_store/registration/distributed_registry.ex
@@ -25,7 +25,11 @@ defmodule EventStore.Registration.DistributedRegistry do
   @doc """
   Subscribes the caller to the given topic.
   """
-  @spec subscribe(binary, mapper: (RecordedEvent.t() -> any())) :: :ok | {:error, term}
+  @spec subscribe(
+          binary,
+          selector: (RecodedEvent.t() -> any()),
+          mapper: (RecordedEvent.t() -> any())
+        ) :: :ok | {:error, term}
   @impl EventStore.Registration
   def subscribe(topic, opts) do
     LocalRegistry.subscribe(topic, opts)

--- a/lib/event_store/registration/registration.ex
+++ b/lib/event_store/registration/registration.ex
@@ -29,7 +29,11 @@ defmodule EventStore.Registration do
   @doc """
   Subscribes the caller to the given topic.
   """
-  @spec subscribe(binary, mapper: (RecordedEvent.t() -> any())) :: :ok | {:error, term}
+  @spec subscribe(
+          binary,
+          selector: (RecordedEvent.t() -> any()),
+          mapper: (RecordedEvent.t() -> any())
+        ) :: :ok | {:error, term}
   def subscribe(topic, opts \\ []), do: registry_provider().subscribe(topic, opts)
 
   @doc """

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -11,6 +11,7 @@ defmodule EventStore.Subscriptions.SubscriptionState do
             last_seen: 0,
             last_ack: 0,
             last_received: nil,
+            selector: nil,
             mapper: nil,
             max_size: nil,
             pending_events: []

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -43,6 +43,22 @@ defmodule EventStore.Subscriptions.SingleSubscriptionFsmTest do
 
       assert subscription.data.mapper == mapper
     end
+
+    test "create subscription to a single stream with event selector function", context do
+      selector = fn event -> event.event_number > 0 end
+      subscription = create_subscription(context, selector: selector)
+
+      assert subscription.data.selector == selector 
+    end
+
+    test "create subscription to a single stream with event selector function and mapper function", context do
+      selector = fn event -> event.event_number > 0 end
+      mapper = fn event -> event.event_number end
+      subscription = create_subscription(context, selector: selector, mapper: mapper)
+
+      assert subscription.data.selector == selector 
+      assert subscription.data.mapper == mapper
+    end
   end
 
   describe "catch-up subscription on empty stream" do


### PR DESCRIPTION
Based on #109 this would follow GenStage's lead by implementing a `selector` function that is run first filtering all events before being sent to subscribers.