### PR TITLE
Remove dependency on psql for storage_up, storage_down and migrate

### DIFF
--- a/lib/event_store/storage/database.ex
+++ b/lib/event_store/storage/database.ex
@@ -1,33 +1,11 @@
 defmodule EventStore.Storage.Database do
   @moduledoc false
-  
+
   require Logger
 
-  def create(config) do
-    database = Keyword.fetch!(config, :database)
-    encoding = Keyword.get(config, :encoding, "UTF8")
+  def create(config), do: storage_up(config)
 
-    {output, status} =
-      run_with_psql(config, "template1", "CREATE DATABASE \"#{database}\" ENCODING='#{encoding}'")
-
-    cond do
-      status == 0 -> :ok
-      String.contains?(output, "42P04") -> {:error, :already_up}
-      true -> {:error, output}
-    end
-  end
-
-  def drop(config) do
-    database = Keyword.fetch!(config, :database)
-
-    {output, status} = run_with_psql(config, "template1", "DROP DATABASE \"#{database}\"")
-
-    cond do
-      status == 0 -> :ok
-      String.contains?(output, "3D000") -> {:error, :already_down}
-      true -> {:error, output}
-    end
-  end
+  def drop(config), do: storage_down(config)
 
   def migrate(config, migration) do
     database = Keyword.fetch!(config, :database)
@@ -112,5 +90,132 @@ defmodule EventStore.Storage.Database do
         host,
         "--no-password"
       ]
+  end
+
+  # Taken from ecto/adapters/postgres.ex
+  defp storage_up(opts) do
+    database =
+      Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
+
+    encoding = opts[:encoding] || "UTF8"
+    opts = Keyword.put(opts, :database, "postgres")
+
+    command =
+      ~s(CREATE DATABASE "#{database}" ENCODING '#{encoding}')
+      |> concat_if(opts[:template], &"TEMPLATE=#{&1}")
+      |> concat_if(opts[:lc_ctype], &"LC_CTYPE='#{&1}'")
+      |> concat_if(opts[:lc_collate], &"LC_COLLATE='#{&1}'")
+
+    case run_query(command, opts) do
+      {:ok, _} ->
+        :ok
+
+      {:error, %{postgres: %{code: :duplicate_database}}} ->
+        {:error, :already_up}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  defp concat_if(content, nil, _fun), do: content
+  defp concat_if(content, value, fun), do: content <> " " <> fun.(value)
+
+  defp storage_down(opts) do
+    database =
+      Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
+
+    command = "DROP DATABASE \"#{database}\""
+    opts = Keyword.put(opts, :database, "postgres")
+
+    case run_query(command, opts) do
+      {:ok, _} ->
+        :ok
+
+      {:error, %{postgres: %{code: :invalid_catalog_name}}} ->
+        {:error, :already_down}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  defp run_query(sql, opts) do
+    {:ok, _} = Application.ensure_all_started(:postgrex)
+
+    opts =
+      opts
+      |> Keyword.drop([:name, :log])
+      |> Keyword.put(:pool, DBConnection.Connection)
+      |> Keyword.put(:backoff_type, :stop)
+
+    {:ok, pid} = Task.Supervisor.start_link()
+
+    task =
+      Task.Supervisor.async_nolink(pid, fn ->
+        {:ok, conn} = Postgrex.start_link(opts)
+
+        value = execute(conn, sql, [], opts)
+        GenServer.stop(conn)
+        value
+      end)
+
+    timeout = Keyword.get(opts, :timeout, 15_000)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, result}} ->
+        {:ok, result}
+
+      {:ok, {:error, error}} ->
+        {:error, error}
+
+      {:exit, {%{__struct__: struct} = error, _}}
+      when struct in [Postgrex.Error, DBConnection.Error] ->
+        {:error, error}
+
+      {:exit, reason} ->
+        {:error, RuntimeError.exception(Exception.format_exit(reason))}
+
+      nil ->
+        {:error, RuntimeError.exception("command timed out")}
+    end
+  end
+
+  # Taken from ecto/adapters/postgres/connection.ex
+  defp execute(conn, sql, params, opts) when is_binary(sql) or is_list(sql) do
+    query = %Postgrex.Query{name: "", statement: sql}
+    opts = [function: :prepare_execute] ++ opts
+
+    case DBConnection.prepare_execute(conn, query, params, opts) do
+      {:ok, _, result} ->
+        {:ok, result}
+
+      {:error, %Postgrex.Error{}} = error ->
+        error
+
+      {:error, err} ->
+        raise err
+    end
+  end
+
+  defp execute(conn, %{} = query, params, opts) do
+    opts = [function: :execute] ++ opts
+
+    case DBConnection.execute(conn, query, params, opts) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, %ArgumentError{} = err} ->
+        {:reset, err}
+
+      {:error, %Postgrex.Error{postgres: %{code: :feature_not_supported}} = err} ->
+        {:reset, err}
+
+      {:error, %Postgrex.Error{}} = error ->
+        error
+
+      {:error, err} ->
+        raise err
+    end
   end
 end


### PR DESCRIPTION
This is a first commit to lower the dependency on `psql`. It shamelessly uses code from Ecto Postgres adapter as they have been through this issue. Follow the discussion [here](https://github.com/elixir-ecto/ecto/issues/854). I've done this so that I can use a dockerized Postgres instance with a local running elixir installation.

The idea of copying is that it will be easier to update the code here if the adapter is also updated.

Migrate is still dependant on `psql`. We might tackle this on another PR.

Please, feel free to close this if you think that this is not the approach. 

This might help solving #1 .