### PR TITLE
allow callers to omit event_type when event data is a struct

### DIFF
--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -145,6 +145,18 @@ defmodule EventStore.Streams.Stream do
     end)
   end
 
+  defp map_to_recorded_event(
+         %EventData{
+           data: %{__struct__: event_type},
+           event_type: nil
+         } = event,
+         created_at,
+         serializer
+       ) do
+    %{event | event_type: Atom.to_string(event_type)}
+    |> map_to_recorded_event(created_at, serializer)
+  end
+
   defp map_to_recorded_event(%EventData{
       causation_id: causation_id,
       correlation_id: correlation_id,


### PR DESCRIPTION
As explained in #116 `event_type` is required for each event to be passed into _eventstore_ even though it could be detected within the app. This is the technical implementation to add the possibility to omit this argument when a _struct_ is passed.

A possible second step that is *not* part of this PR could be to refactor/rewrite the documentation to remove the `event_type` from the examples and thus invert the regular flow to omit it, and only pass it when needed.

---
fixes #116 