### PR TITLE
Supports query parameters in URL

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -3,7 +3,7 @@ defmodule EventStore.Config do
   Provides access to the EventStore configuration.
   """
 
-  @integer_url_query_params ["port", "pool_size"]
+  @integer_url_query_params ["pool_size"]
 
   @doc """
   Get the event store configuration for the environment.

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -3,6 +3,8 @@ defmodule EventStore.Config do
   Provides access to the EventStore configuration.
   """
 
+  @integer_url_query_params ["port", "pool_size"]
+
   @doc """
   Get the event store configuration for the environment.
   """
@@ -52,15 +54,49 @@ defmodule EventStore.Config do
     destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
     "/" <> database = info.path
 
-    opts = [
+    opts = Enum.reject([
       username: username,
       password: password,
       database: database,
       hostname: info.host,
       port: info.port
-    ]
+    ], fn {_k, v} -> is_nil(v) end)
 
-    Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
+    query_opts = parse_uri_query(info)
+
+    for {k, v} <- opts ++ query_opts,
+        not is_nil(v),
+        do: {k, if(is_binary(v), do: URI.decode(v), else: v)}
+  end
+
+  defp parse_uri_query(%URI{query: nil}),
+    do: []
+  defp parse_uri_query(%URI{query: query}) do
+    query
+    |> URI.query_decoder()
+    |> Enum.reduce([], fn
+      {"ssl", "true"}, acc ->
+        [{:ssl, true}] ++ acc
+
+      {"ssl", "false"}, acc ->
+        [{:ssl, false}] ++ acc
+
+      {key, value}, acc when key in @integer_url_query_params ->
+        [{String.to_atom(key), parse_integer!(key, value)}] ++ acc
+
+      {key, _value}, _acc ->
+        raise ArgumentError, message: "unsupported query parameter `#{key}`"
+    end)
+  end
+
+  defp parse_integer!(key, value) do
+    case Integer.parse(value) do
+      {int, ""} ->
+        int
+
+      _ ->
+        raise ArgumentError, message: "can not parse value `#{value}` for parameter `#{key}` as an integer"
+    end
   end
 
   @doc """

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -35,6 +35,22 @@ defmodule EventStore.ConfigTest do
            ]
   end
 
+  test "parse url with query parameters" do
+    original = [url: "postgres://username:password@localhost/database?ssl=true&pool_size=5"]
+
+    config = Config.parse(original)
+
+    assert config == [
+             username: "username",
+             password: "password",
+             database: "database",
+             hostname: "localhost",
+             pool_size: 5,
+             ssl: true,
+             pool: DBConnection.Poolboy
+           ]
+  end
+
   test "parse database url from environment variable" do
     set_envs(%{"ES_URL" => "postgres://username:password@localhost/database"})
 


### PR DESCRIPTION
Ecto does support query parameters, such as `ssl` or `pool_size`. This PR adds the supports in Commanded as well.

[Some of this PR](https://github.com/elixir-ecto/ecto/blob/108bafacc3f378bb0d43e6037f6d501fb8956ed4/lib/ecto/repo/supervisor.ex#L115-L145) is actually borrowed from Ecto.