### PR TITLE
use single plt file for caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /cover
 /deps
 /doc
+/priv/plts/*.plt
+/priv/plts/*.plt.hash
 erl_crash.dump
 *.ez
 *.dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: elixir
 
+cache:
+  directories:
+  - priv/plts
+
 elixir:
   - 1.6.5
 

--- a/mix.exs
+++ b/mix.exs
@@ -122,7 +122,8 @@ EventStore using PostgreSQL for persistence.
   defp dialyzer do
     [
       plt_add_apps: [:poison, :ex_unit],
-      plt_add_deps: :app_tree
+      plt_add_deps: :app_tree,
+      plt_file: {:no_warn, "priv/plts/eventstore.plt"}
     ]
   end
 


### PR DESCRIPTION
After adding dialyzer to eventstore build times went up a lot. Because we need to build the PLT files for every build. This PR addresses this by compiling them into a single plt file and cache this for CI.