### PR TITLE
Subscription should notifying pending events after all filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - Fix: socket closing causes the eventstore to never receive notifications ([#130](https://github.com/commanded/eventstore/pull/130)).
+- Subscription should notifying pending events after all filtered ([#131](https://github.com/commanded/eventstore/pull/131/files)).
 
 ## 0.15.0
 

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -11,6 +11,8 @@ defmodule EventStore.Tasks.Migrate do
     "0.14.0"
   ]
 
+  @dialyzer {:no_return, exec: 2, handle_response: 1}
+
   @doc """
   Run task
 

--- a/test/subscriptions/susbcription_selector_test.exs
+++ b/test/subscriptions/susbcription_selector_test.exs
@@ -1,0 +1,28 @@
+defmodule EventStore.Subscriptions.SubscriptionSelectorTest do
+  use EventStore.StorageCase
+
+  import Integer, only: [is_odd: 1]
+  import EventStore.SubscriptionHelpers
+
+  alias EventStore.{RecordedEvent, SelectorSubscriber}
+  alias EventStore.EventFactory.Event
+
+  describe "subscription selector" do
+    test "should receive only selected events" do
+      subscription_name = UUID.uuid4()
+      stream_uuid = UUID.uuid4()
+
+      SelectorSubscriber.start_link(stream_uuid, subscription_name, self(), 1)
+
+      for i <- 1..100 do
+        :ok = append_to_stream(stream_uuid, 1, i - 1)
+      end
+
+      for i <- 1..100, is_odd(i) do
+        assert_receive {:events, [%RecordedEvent{data: %Event{event: ^i}}]}
+      end
+
+      refute_receive {:events, _events}
+    end
+  end
+end

--- a/test/support/selector_subscriber.ex
+++ b/test/support/selector_subscriber.ex
@@ -1,0 +1,64 @@
+defmodule EventStore.SelectorSubscriber do
+  import Integer, only: [is_odd: 1]
+
+  defmodule State do
+    defstruct [
+      :stream_uuid,
+      :subscription_name,
+      :subscription,
+      :reply_to,
+      :delay
+    ]
+  end
+
+  alias EventStore.SelectorSubscriber.State
+
+  def start_link(stream_uuid, subscription_name, reply_to, delay \\ 0) do
+    state = %State{
+      stream_uuid: stream_uuid,
+      subscription_name: subscription_name,
+      reply_to: reply_to,
+      delay: delay
+    }
+
+    GenServer.start_link(__MODULE__, state)
+  end
+
+  def init(%State{} = state) do
+    %State{stream_uuid: stream_uuid, subscription_name: subscription_name} = state
+
+    {:ok, subscription} =
+      EventStore.subscribe_to_stream(
+        stream_uuid,
+        subscription_name,
+        self(),
+        selector: &test_selector/1
+      )
+
+    {:ok, %{state | subscription: subscription}}
+  end
+
+  def handle_info({:events, events} = message, %State{} = state) do
+    %State{subscription: subscription, reply_to: reply_to} = state
+
+    processing_delay(state)
+
+    send(reply_to, message)
+
+    :ok = EventStore.ack(subscription, events)
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  def handle_call(:received_events, _from, %State{} = state) do
+    %State{} = state
+  end
+
+  def test_selector(%EventStore.RecordedEvent{data: %{event: event}}) when is_odd(event), do: true
+  def test_selector(_recorded_event), do: false
+
+  defp processing_delay(%State{delay: 0}), do: :ok
+  defp processing_delay(%State{delay: delay}), do: Process.sleep(delay)
+end

--- a/test/support/subscription_helpers.ex
+++ b/test/support/subscription_helpers.ex
@@ -1,0 +1,39 @@
+defmodule EventStore.SubscriptionHelpers do
+  import ExUnit.Assertions
+
+  alias EventStore.{EventFactory, RecordedEvent}
+  alias EventStore.Subscriptions.Subscription
+
+  def append_to_stream(stream_uuid, event_count, expected_version \\ 0) do
+    events = EventFactory.create_events(event_count, expected_version + 1)
+
+    EventStore.append_to_stream(stream_uuid, expected_version, events)
+  end
+
+  @doc """
+  Subscribe to all streams and wait for the subscription to be subscribed.
+  """
+  def subscribe_to_all_streams(subscription_name, subscriber, opts \\ []) do
+    {:ok, subscription} = EventStore.subscribe_to_all_streams(subscription_name, subscriber, opts)
+
+    assert_receive {:subscribed, ^subscription}
+
+    {:ok, subscription}
+  end
+
+  def receive_and_ack(subscription, expected_stream_uuid, expected_intial_event_number) do
+    assert_receive {:events, received_events}
+    assert length(received_events) == 10
+
+    received_events
+    |> Enum.with_index(expected_intial_event_number)
+    |> Enum.each(fn {event, expected_event_number} ->
+      %RecordedEvent{event_number: event_number} = event
+
+      assert event_number == expected_event_number
+      assert event.stream_uuid == expected_stream_uuid
+
+      Subscription.ack(subscription, event)
+    end)
+  end
+end


### PR DESCRIPTION
Fix bug when all events in a batch are filtered by the subscriptions `selector/1` function the event are acknowledged but subsequent pending events are not sent to the subscriber.

Fixes #128