### PR TITLE
Add :socket and :socket_dir options

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -28,6 +28,8 @@ defmodule EventStore.Config do
     |> Enum.reduce([], fn
       {:url, value}, config -> Keyword.merge(config, value |> get_config_value() |> parse_url())
       {:port, value}, config -> Keyword.put(config, :port, get_config_integer(value))
+      {:socket, value}, config -> Keyword.put(config, :socket, get_config_value(value))
+      {:socket_dir, value}, config -> Keyword.put(config, :socket_dir, get_config_value(value))
       {key, value}, config -> Keyword.put(config, key, get_config_value(value))
     end)
     |> Keyword.merge(pool: DBConnection.Poolboy)
@@ -138,6 +140,8 @@ defmodule EventStore.Config do
     :hostname,
     :port,
     :types,
+    :socket,
+    :socket_dir,
     :ssl,
     :ssl_opts
   ]

--- a/lib/event_store/storage/database.ex
+++ b/lib/event_store/storage/database.ex
@@ -59,7 +59,7 @@ defmodule EventStore.Storage.Database do
         port -> ["-p", to_string(port) | args]
       end
 
-    host = config[:hostname] || System.get_env("PGHOST") || "localhost"
+    host = config[:socket_dir] || config[:hostname] || System.get_env("PGHOST") || "localhost"
 
     args ++
       [

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -21,6 +21,42 @@ defmodule EventStore.ConfigTest do
            ]
   end
 
+  test "parse socket" do
+    original = [
+      username: "postgres",
+      socket: "/path/to/socket",
+      database: "eventstore_test",
+      password: "postgres",
+      pool: DBConnection.Poolboy
+    ]
+
+    assert Config.parse(original) == [
+             password: "postgres",
+             database: "eventstore_test",
+             socket: "/path/to/socket",
+             username: "postgres",
+             pool: DBConnection.Poolboy
+           ]
+  end
+
+  test "parse socket_dir" do
+    original = [
+      username: "postgres",
+      socket_dir: "/path/to/socket_dir",
+      database: "eventstore_test",
+      password: "postgres",
+      pool: DBConnection.Poolboy
+    ]
+
+    assert Config.parse(original) == [
+             password: "postgres",
+             database: "eventstore_test",
+             socket_dir: "/path/to/socket_dir",
+             username: "postgres",
+             pool: DBConnection.Poolboy
+           ]
+  end
+
   test "parse url" do
     original = [url: "postgres://username:password@localhost/database"]
 


### PR DESCRIPTION
This pull request adds support for `:socket` and `:socket_dir` options to allow Postgrex to use UNIX socket files to connect to the database.

This type of connection is required for some deployment scenarios (eg, Google App Engine).