### PR TITLE
Send `:subscribed` message to all subscribers connected to a subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `:socket` and `:socket_dir` config options ([#132](https://github.com/commanded/eventstore/pull/132)).
 - Rename `uuid` dependency to `elixir_uuid` ([#135](https://github.com/commanded/eventstore/pull/135)).
 - Subscription concurrency ([#134](https://github.com/commanded/eventstore/pull/134)).
+- Send `:subscribed` message to all subscribers connected to a subscription ([#136](https://github.com/commanded/eventstore/pull/136)).
 
 ## 0.15.1
 

--- a/lib/event_store/notifications/reader.ex
+++ b/lib/event_store/notifications/reader.ex
@@ -8,6 +8,8 @@ defmodule EventStore.Notifications.Reader do
   alias EventStore.Notifications.Listener
   alias EventStore.{RecordedEvent, Storage}
 
+  @conn EventStore.Notifications.Reader.Postgrex
+
   def start_link(serializer) do
     GenStage.start_link(__MODULE__, serializer, name: __MODULE__)
   end
@@ -37,12 +39,7 @@ defmodule EventStore.Notifications.Reader do
     count = to_stream_version - from_stream_version + 1
 
     with {:ok, events} <-
-           Storage.read_stream_forward(
-             EventStore.Notifications.Reader.Postgrex,
-             stream_id,
-             from_stream_version,
-             count
-           ),
+           Storage.read_stream_forward(@conn, stream_id, from_stream_version, count),
          deserialized_events <- deserialize_recorded_events(events, serializer) do
       {stream_uuid, deserialized_events}
     end

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -50,8 +50,6 @@ defmodule EventStore.Notifications.Supervisor do
            [
              {PostgrexNotifications, :start_link, [postgrex_config]},
              [
-               after_restart: &Listener.reconnect/0,
-               after_exit: &Listener.disconnect/0,
                name: Listener.Postgrex
              ]
            ]},

--- a/lib/event_store/storage/subscription.ex
+++ b/lib/event_store/storage/subscription.ex
@@ -98,9 +98,9 @@ defmodule EventStore.Storage.Subscription do
     def execute(conn, stream_uuid, subscription_name, start_from, opts) do
       _ =
         Logger.debug(fn ->
-          "Attempting to create subscription on stream \"#{stream_uuid}\" named \"#{
-            subscription_name
-          }\""
+          "Attempting to create subscription on stream " <>
+            inspect(stream_uuid) <>
+            " named " <> inspect(subscription_name) <> " starting from #" <> inspect(start_from)
         end)
 
       conn

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -33,14 +33,9 @@ defmodule EventStore.Subscriptions do
   end
 
   defp do_subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts) do
-    case Subscriptions.Supervisor.subscribe_to_stream(
-           stream_uuid,
-           subscription_name,
-           subscriber,
-           opts
-         ) do
+    case Subscriptions.Supervisor.start_subscription(stream_uuid, subscription_name, opts) do
       {:ok, subscription} ->
-        {:ok, subscription}
+        Subscription.connect(subscription, subscriber, opts)
 
       {:error, {:already_started, subscription}} ->
         case Keyword.get(opts, :concurrency_limit) do

--- a/lib/event_store/subscriptions/subscriber.ex
+++ b/lib/event_store/subscriptions/subscriber.ex
@@ -41,6 +41,10 @@ defmodule EventStore.Subscriptions.Subscriber do
     }
   end
 
+  def reset_in_flight(%Subscriber{} = subscriber) do
+    %Subscriber{subscriber | in_flight: [], partition_key: nil}
+  end
+
   @doc """
   Acknowledge the in-flight event by number and all events sent to the
   subscriber before the ack'd event.

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -74,8 +74,8 @@ defmodule EventStore.Subscriptions.Subscription do
   Allow a short delay for the connection to become available before attempting
   to reconnect.
   """
-  def reconnect(subscription) do
-    _ref = Process.send_after(subscription, :reconnect, 5_000)
+  def reconnect(subscription, delay \\ 5_000) do
+    _ref = Process.send_after(subscription, :reconnect, delay)
     :ok
   end
 

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -10,28 +10,22 @@ defmodule EventStore.Subscriptions.Subscription do
   use GenServer
   require Logger
 
-  alias EventStore.{RecordedEvent, Registration}
+  alias EventStore.RecordedEvent
   alias EventStore.Subscriptions.{SubscriptionFsm, Subscription, SubscriptionState}
 
   defstruct [
-    :conn,
     :retry_ref,
     :stream_uuid,
     :subscription_name,
-    :subscriber,
     :subscription,
-    :retry_interval,
-    subscription_opts: []
+    :retry_interval
   ]
 
-  def start_link(conn, stream_uuid, subscription_name, subscriber, subscription_opts, opts \\ []) do
+  def start_link(conn, stream_uuid, subscription_name, subscription_opts, opts \\ []) do
     state = %Subscription{
-      conn: conn,
       stream_uuid: stream_uuid,
       subscription_name: subscription_name,
-      subscriber: subscriber,
-      subscription: SubscriptionFsm.new(),
-      subscription_opts: subscription_opts,
+      subscription: SubscriptionFsm.new(conn, stream_uuid, subscription_name, subscription_opts),
       retry_interval: subscription_retry_interval()
     }
 
@@ -106,32 +100,41 @@ defmodule EventStore.Subscriptions.Subscription do
 
   @doc false
   def init(%Subscription{} = state) do
-    send(self(), :subscribe_to_stream)
-
     {:ok, state}
   end
 
-  def handle_info(:subscribe_to_stream, %Subscription{} = state) do
+  def handle_info(:subscribe_to_stream, %Subscription{subscription: subscription} = state) do
     _ = Logger.debug(fn -> describe(state) <> " subscribe to stream" end)
 
-    {:noreply, subscribe_to_stream(state)}
+    state =
+      subscription
+      |> SubscriptionFsm.subscribe()
+      |> apply_subscription_to_state(state)
+
+    {:noreply, state}
   end
 
   def handle_info({:events, events}, %Subscription{subscription: subscription} = state) do
     _ = Logger.debug(fn -> describe(state) <> " received #{length(events)} event(s)" end)
 
-    subscription = SubscriptionFsm.notify_events(subscription, events)
+    state =
+      subscription
+      |> SubscriptionFsm.notify_events(events)
+      |> apply_subscription_to_state(state)
 
-    {:noreply, apply_subscription_to_state(subscription, state)}
+    {:noreply, state}
   end
 
   def handle_info(:reconnect, %Subscription{subscription: subscription} = state) do
     _ = Logger.debug(fn -> describe(state) <> " reconnected" end)
 
-    state = cancel_retry_timer(state)
-    subscription = SubscriptionFsm.reconnect(subscription)
+    state =
+      subscription
+      |> SubscriptionFsm.reconnect()
+      |> apply_subscription_to_state(state)
+      |> cancel_retry_timer()
 
-    {:noreply, apply_subscription_to_state(subscription, state)}
+    {:noreply, state}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %Subscription{} = state) do
@@ -142,56 +145,65 @@ defmodule EventStore.Subscriptions.Subscription do
         describe(state) <> " subscriber #{inspect(pid)} down due to: #{inspect(reason)}"
       end)
 
-    subscription = SubscriptionFsm.unsubscribe(subscription, pid)
+    state =
+      subscription
+      |> SubscriptionFsm.unsubscribe(pid)
+      |> apply_subscription_to_state(state)
 
-    state = apply_subscription_to_state(subscription, state)
-
-    case subscription do
-      %SubscriptionFsm{state: :unsubscribed} ->
-        {:stop, reason, state}
-
-      %SubscriptionFsm{} ->
-        {:noreply, state}
+    if unsubscribed?(state) do
+      {:stop, reason, state}
+    else
+      {:noreply, state}
     end
   end
 
-  def handle_cast(:subscribe_to_events, %Subscription{subscription: subscription} = state) do
-    :ok = subscribe_to_events(state)
-    :ok = notify_subscribed(state)
-
-    subscription = SubscriptionFsm.subscribed(subscription)
-
-    {:noreply, apply_subscription_to_state(subscription, state)}
-  end
-
   def handle_cast(:catch_up, %Subscription{subscription: subscription} = state) do
-    subscription = SubscriptionFsm.catch_up(subscription)
+    state =
+      subscription
+      |> SubscriptionFsm.catch_up()
+      |> apply_subscription_to_state(state)
 
-    {:noreply, apply_subscription_to_state(subscription, state)}
+    {:noreply, state}
   end
 
   def handle_cast(:disconnect, %Subscription{subscription: subscription} = state) do
     _ = Logger.debug(fn -> describe(state) <> " disconnected" end)
 
-    subscription = SubscriptionFsm.disconnect(subscription)
+    state =
+      subscription
+      |> SubscriptionFsm.disconnect()
+      |> apply_subscription_to_state(state)
 
-    {:noreply, apply_subscription_to_state(subscription, state)}
+    {:noreply, state}
   end
 
   def handle_cast({:ack, ack, subscriber}, %Subscription{subscription: subscription} = state) do
-    subscription = SubscriptionFsm.ack(subscription, ack, subscriber)
+    state =
+      subscription
+      |> SubscriptionFsm.ack(ack, subscriber)
+      |> apply_subscription_to_state(state)
 
-    {:noreply, apply_subscription_to_state(subscription, state)}
+    {:noreply, state}
   end
 
   def handle_call({:connect, subscriber, opts}, _from, %Subscription{} = state) do
-    %Subscription{subscription: subscription} = state
+    %Subscription{
+      subscription:
+        %SubscriptionFsm{data: %SubscriptionState{subscribers: subscribers}} = subscription
+    } = state
 
-    with :ok <- ensure_not_already_subscribed(subscription, subscriber),
-         :ok <- ensure_within_concurrency_limit(subscription, opts) do
-      subscription = SubscriptionFsm.connect_subscriber(subscription, subscriber, opts)
+    _ =
+      Logger.debug(fn ->
+        describe(state) <> " attempting to connect subscriber " <> inspect(subscriber)
+      end)
 
-      state = %Subscription{state | subscription: subscription}
+    with :ok <- ensure_not_already_subscribed(subscribers, subscriber),
+         :ok <- ensure_within_concurrency_limit(subscribers, opts) do
+      state =
+        subscription
+        |> SubscriptionFsm.connect_subscriber(subscriber, opts)
+        |> SubscriptionFsm.subscribe()
+        |> apply_subscription_to_state(state)
 
       {:reply, {:ok, self()}, state}
     else
@@ -200,17 +212,18 @@ defmodule EventStore.Subscriptions.Subscription do
     end
   end
 
-  def handle_call({:unsubscribe, pid}, _from, %Subscription{subscription: subscription} = state) do
-    subscription = SubscriptionFsm.unsubscribe(subscription, pid)
+  def handle_call({:unsubscribe, pid}, _from, %Subscription{} = state) do
+    %Subscription{subscription: subscription} = state
 
-    state = apply_subscription_to_state(subscription, state)
+    state =
+      subscription
+      |> SubscriptionFsm.unsubscribe(pid)
+      |> apply_subscription_to_state(state)
 
-    case subscription do
-      %SubscriptionFsm{state: :unsubscribed} ->
-        {:stop, :shutdown, :ok, state}
-
-      %SubscriptionFsm{} ->
-        {:reply, :ok, state}
+    if unsubscribed?(state) do
+      {:stop, :shutdown, :ok, state}
+    else
+      {:reply, :ok, state}
     end
   end
 
@@ -234,16 +247,6 @@ defmodule EventStore.Subscriptions.Subscription do
     retry_ref = Process.send_after(self(), :subscribe_to_stream, retry_interval)
 
     %Subscription{state | retry_ref: retry_ref}
-  end
-
-  defp handle_subscription_state(
-         %Subscription{subscription: %SubscriptionFsm{state: :subscribe_to_events}} = state
-       ) do
-    _ = Logger.debug(fn -> describe(state) <> " subscribing to events" end)
-
-    :ok = GenServer.cast(self(), :subscribe_to_events)
-
-    state
   end
 
   defp handle_subscription_state(
@@ -277,22 +280,7 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   # No-op for all other subscription states.
-  defp handle_subscription_state(state), do: state
-
-  defp subscribe_to_stream(%Subscription{} = state) do
-    %Subscription{
-      conn: conn,
-      stream_uuid: stream_uuid,
-      subscription_name: subscription_name,
-      subscriber: subscriber,
-      subscription: subscription,
-      subscription_opts: opts
-    } = state
-
-    subscription
-    |> SubscriptionFsm.subscribe(conn, stream_uuid, subscription_name, subscriber, opts)
-    |> apply_subscription_to_state(state)
-  end
+  defp handle_subscription_state(%Subscription{} = state), do: state
 
   defp cancel_retry_timer(%Subscription{retry_ref: ref} = state) when is_reference(ref) do
     Process.cancel_timer(ref)
@@ -301,17 +289,6 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   defp cancel_retry_timer(%Subscription{} = state), do: state
-
-  defp subscribe_to_events(%Subscription{stream_uuid: stream_uuid}) do
-    Registration.subscribe(stream_uuid)
-  end
-
-  # notify the subscriber that this subscription has successfully subscribed to events
-  defp notify_subscribed(%Subscription{subscriber: subscriber}) do
-    send(subscriber, {:subscribed, self()})
-
-    :ok
-  end
 
   # Get the delay between subscription attempts, in milliseconds, from app
   # config. The default value is one minute and minimum allowed value is one
@@ -329,30 +306,27 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   # Prevent duplicate subscriptions from same process.
-  defp ensure_not_already_subscribed(%SubscriptionFsm{} = subscription, pid) do
-    unless subscribed?(subscription, pid) do
+  defp ensure_not_already_subscribed(subscribers, pid) do
+    unless Map.has_key?(subscribers, pid) do
       :ok
     else
       {:error, :already_subscribed}
     end
   end
 
-  defp subscribed?(%SubscriptionFsm{data: %SubscriptionState{subscribers: subscribers}}, pid),
-    do: Map.has_key?(subscribers, pid)
-
   # Prevent more subscribers than requested concurrency limit.
-  defp ensure_within_concurrency_limit(%SubscriptionFsm{} = subscription, opts) do
+  defp ensure_within_concurrency_limit(subscribers, opts) do
     concurrency_limit = Keyword.get(opts, :concurrency_limit, 1)
 
-    if subscriber_count(subscription) < concurrency_limit do
+    if Map.size(subscribers) < concurrency_limit do
       :ok
     else
       {:error, :too_many_subscribers}
     end
   end
 
-  defp subscriber_count(%SubscriptionFsm{data: %SubscriptionState{subscribers: subscribers}}),
-    do: map_size(subscribers)
+  def unsubscribed?(%Subscription{subscription: %SubscriptionFsm{state: :unsubscribed}}), do: true
+  def unsubscribed?(%Subscription{}), do: false
 
   defp describe(%Subscription{stream_uuid: stream_uuid, subscription_name: name}),
     do: "Subscription #{inspect(name)}@#{inspect(stream_uuid)}"

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -15,6 +15,7 @@ defmodule EventStore.Subscriptions.SubscriptionState do
     last_sent: 0,
     last_ack: 0,
     queue_size: 0,
+    buffer_size: 1,
     subscribers: %{},
     partitions: %{},
     processed_event_ids: MapSet.new()

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -11,6 +11,7 @@ defmodule EventStore.Subscriptions.SubscriptionState do
     :mapper,
     :max_size,
     :partition_by,
+    :lock_ref,
     last_received: 0,
     last_sent: 0,
     last_ack: 0,

--- a/lib/event_store/subscriptions/supervisor.ex
+++ b/lib/event_store/subscriptions/supervisor.ex
@@ -11,13 +11,12 @@ defmodule EventStore.Subscriptions.Supervisor do
     Supervisor.start_link(__MODULE__, args, name: __MODULE__)
   end
 
-  def subscribe_to_stream(stream_uuid, subscription_name, subscriber, subscription_opts) do
+  def start_subscription(stream_uuid, subscription_name, subscription_opts) do
     name = {:via, Registry, registry_name(stream_uuid, subscription_name)}
 
     Supervisor.start_child(__MODULE__, [
       stream_uuid,
       subscription_name,
-      subscriber,
       subscription_opts,
       [name: name]
     ])

--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -23,8 +23,6 @@ defmodule EventStore.Supervisor do
         MonitoredServer.child_spec([
           {Postgrex, :start_link, [Config.sync_connect_postgrex_opts(config)]},
           [
-            after_exit: &AdvisoryLocks.disconnect/0,
-            after_restart: &AdvisoryLocks.reconnect/0,
             name: AdvisoryLocks.Postgrex
           ]
         ]),

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -1,6 +1,8 @@
 defmodule EventStore.Subscriptions.SingleSubscriptionFsmTest do
   use EventStore.Subscriptions.StreamSubscriptionTestCase, stream_uuid: UUID.uuid4()
 
+  alias EventStore.EventFactory
+
   setup [:append_events_to_another_stream]
 
   defp create_recorded_events(%{stream_uuid: stream_uuid}, count, initial_event_number \\ 1) do

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -1,7 +1,7 @@
 defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   use EventStore.StorageCase
 
-  alias EventStore.{Config, EventFactory, ProcessHelper, Subscriptions, Wait}
+  alias EventStore.{EventFactory, ProcessHelper, Subscriptions, Wait}
   alias EventStore.Subscriptions.Subscription
   alias EventStore.Support.CollectingSubscriber
 
@@ -469,89 +469,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(received_events, :data) == pluck(expected_events, :data)
       assert pluck(received_events, :metadata) == pluck(expected_events, :metadata)
       refute pluck(received_events, :created_at) |> Enum.any?(&is_nil/1)
-    end
-  end
-
-  describe "duplicate subscriptions" do
-    setup [:lock_subscription, :create_subscription]
-
-    test "should only allow single active subscription", context do
-      %{conn2: conn2, subscription: subscription} = context
-
-      stream1_uuid = append_events_to_stream(1)
-
-      # subscriber should not receive events until subscribed
-      refute_receive {:events, _received_events}
-
-      # release lock, allowing subscriber to subscribe
-      ProcessHelper.shutdown(conn2)
-
-      # subscription should now be subscribed
-      assert_receive {:subscribed, ^subscription}
-
-      stream2_uuid = append_events_to_stream(2)
-
-      # subscriber should now start receiving events
-      assert_receive {:events, received_events}, 5_000
-      assert length(received_events) == 1
-
-      Enum.each(received_events, fn event ->
-        assert event.stream_uuid == stream1_uuid
-      end)
-
-      :ok = Subscription.ack(subscription, received_events)
-
-      assert_receive {:events, received_events}, 5_000
-      assert length(received_events) == 2
-
-      Enum.each(received_events, fn event ->
-        assert event.stream_uuid == stream2_uuid
-      end)
-
-      :ok = Subscription.ack(subscription, received_events)
-
-      refute_receive {:events, _received_events}
-    end
-
-    defp lock_subscription(_context) do
-      config = Config.parsed() |> Config.sync_connect_postgrex_opts()
-
-      {:ok, conn} = Postgrex.start_link(config)
-
-      EventStore.Storage.Lock.try_acquire_exclusive_lock(conn, 1)
-
-      on_exit(fn ->
-        ProcessHelper.shutdown(conn)
-      end)
-
-      [conn2: conn]
-    end
-
-    defp create_subscription(%{subscription_name: subscription_name}) do
-      {:ok, subscription} =
-        EventStore.Subscriptions.Subscription.start_link(
-          EventStore.Postgrex,
-          "$all",
-          subscription_name,
-          buffer_size: 3,
-          start_from: 0
-        )
-
-      {:ok, ^subscription} =
-        EventStore.Subscriptions.Subscription.connect(subscription, self(), buffer_size: 3)
-
-      refute_receive {:subscribed, ^subscription}
-
-      [subscription: subscription]
-    end
-
-    defp append_events_to_stream(count) do
-      stream_uuid = UUID.uuid4()
-      stream_events = EventFactory.create_events(count)
-
-      :ok = EventStore.append_to_stream(stream_uuid, 0, stream_events)
-
-      stream_uuid
     end
   end
 

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -533,10 +533,12 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
           EventStore.Postgrex,
           "$all",
           subscription_name,
-          self(),
           buffer_size: 3,
           start_from: 0
         )
+
+      {:ok, ^subscription} =
+        EventStore.Subscriptions.Subscription.connect(subscription, self(), buffer_size: 3)
 
       refute_receive {:subscribed, ^subscription}
 

--- a/test/subscriptions/subscription_locking_test.exs
+++ b/test/subscriptions/subscription_locking_test.exs
@@ -1,0 +1,185 @@
+defmodule EventStore.Subscriptions.SubscriptionLockingTest do
+  use EventStore.StorageCase
+
+  alias EventStore.{Config, EventFactory, ProcessHelper}
+  alias EventStore.Subscriptions.Subscription
+
+  @conn EventStore.Postgrex
+
+  setup do
+    subscription_name = UUID.uuid4()
+
+    {:ok, %{subscription_name: subscription_name}}
+  end
+
+  describe "subscription lock lost" do
+    setup [:create_subscription]
+
+    test "should resend in-flight events", %{subscription: subscription} do
+      assert_receive {:subscribed, ^subscription}
+
+      append_events_to_stream(3)
+
+      assert_receive_events([1, 2, 3])
+
+      :ok = Subscription.disconnect(subscription)
+
+      # Acknowledgements should be ignored while subscription is disconnected
+      :ok = Subscription.ack(subscription, 1)
+      :ok = Subscription.ack(subscription, 2)
+      :ok = Subscription.ack(subscription, 3)
+
+      :ok = Subscription.reconnect(subscription, 0)
+
+      # Should receive already sent, but not successfully ack'd events
+      assert_receive_events([1, 2, 3])
+    end
+
+    test "should not send ack'd events before disconnect", %{subscription: subscription} do
+      assert_receive {:subscribed, ^subscription}
+
+      append_events_to_stream(3)
+
+      assert_receive_events([1, 2, 3])
+
+      # Acknowledgement sent before disconnect should be persisted
+      :ok = Subscription.ack(subscription, 1)
+
+      refute_receive {:events, _received_events}
+
+      :ok = Subscription.disconnect(subscription)
+
+      # Acknowledgements sent after subscription disconnect should be ignored
+      :ok = Subscription.ack(subscription, 2)
+      :ok = Subscription.ack(subscription, 3)
+
+      :ok = Subscription.reconnect(subscription, 0)
+
+      # Should receive already sent, but not successfully ack'd events
+      assert_receive_events([2, 3])
+    end
+
+    test "should not send events ack'd by another subscription during disconnect", %{
+      subscription: subscription,
+      subscription_name: subscription_name
+    } do
+      assert_receive {:subscribed, ^subscription}
+
+      append_events_to_stream(3)
+
+      assert_receive_events([1, 2, 3])
+      refute_receive {:events, _received_events}
+
+      :ok = Subscription.disconnect(subscription)
+
+      :ok =
+        EventStore.Storage.Subscription.ack_last_seen_event(
+          @conn,
+          "$all",
+          subscription_name,
+          2,
+          pool: DBConnection.Poolboy
+        )
+
+      :ok = Subscription.reconnect(subscription, 0)
+
+      # Should only receive events not yet ack'd
+      assert_receive_events([3])
+    end
+  end
+
+  describe "duplicate subscriptions" do
+    setup [:lock_subscription, :create_subscription]
+
+    test "should not be subscribed", %{subscription: subscription} do
+      refute_receive {:subscribed, ^subscription}
+    end
+
+    test "should only allow single active subscription", %{
+      conn2: conn2,
+      subscription: subscription
+    } do
+      stream1_uuid = append_events_to_stream(1)
+
+      # Subscriber should not receive events until subscribed
+      refute_receive {:events, _received_events}
+
+      # Release lock, allowing subscriber to subscribe
+      ProcessHelper.shutdown(conn2)
+
+      # Subscription should now be subscribed
+      assert_receive {:subscribed, ^subscription}
+
+      stream2_uuid = append_events_to_stream(2)
+
+      # Subscriber should now start receiving events
+      assert_receive {:events, received_events}
+      assert length(received_events) == 1
+
+      for event <- received_events do
+        assert event.stream_uuid == stream1_uuid
+      end
+
+      :ok = Subscription.ack(subscription, received_events)
+
+      assert_receive {:events, received_events}, 5_000
+      assert length(received_events) == 2
+
+      Enum.each(received_events, fn event ->
+        assert event.stream_uuid == stream2_uuid
+      end)
+
+      :ok = Subscription.ack(subscription, received_events)
+
+      refute_receive {:events, _received_events}
+    end
+  end
+
+  defp lock_subscription(_context) do
+    config = Config.parsed() |> Config.sync_connect_postgrex_opts()
+
+    {:ok, conn} = Postgrex.start_link(config)
+
+    EventStore.Storage.Lock.try_acquire_exclusive_lock(conn, 1)
+
+    on_exit(fn ->
+      ProcessHelper.shutdown(conn)
+    end)
+
+    [conn2: conn]
+  end
+
+  defp create_subscription(%{subscription_name: subscription_name}) do
+    {:ok, subscription} =
+      EventStore.Subscriptions.Subscription.start_link(
+        EventStore.Postgrex,
+        "$all",
+        subscription_name,
+        buffer_size: 3,
+        start_from: 0
+      )
+
+    {:ok, ^subscription} =
+      EventStore.Subscriptions.Subscription.connect(subscription, self(), buffer_size: 3)
+
+    [subscription: subscription]
+  end
+
+  defp append_events_to_stream(count) do
+    stream_uuid = UUID.uuid4()
+    stream_events = EventFactory.create_events(count)
+
+    :ok = EventStore.append_to_stream(stream_uuid, 0, stream_events)
+
+    stream_uuid
+  end
+
+  defp assert_receive_events(expected_event_numbers) do
+    assert_receive {:events, received_events}
+    assert pluck(received_events, :event_number) == expected_event_numbers
+  end
+
+  defp pluck(enumerable, field) do
+    Enum.map(enumerable, &Map.get(&1, field))
+  end
+end


### PR DESCRIPTION
With subscription concurrency (#134) it is now possible to connect multiple subscribers to a single subscription. The `{:subscribed, subscription}` mesage should be sent to each subscriber once the subscription has successfully subscribed.

This pull request changes the subscriptions so that starting a subscription process is separate from connecting one or more subscribers.