### PR TITLE
Fix benchmark suite

### DIFF
--- a/config/bench.exs
+++ b/config/bench.exs
@@ -3,6 +3,8 @@ use Mix.Config
 # no logging for benchmarking
 config :logger, backends: []
 
+config :ex_unit, assert_receive_timeout: 2_000
+
 config :eventstore, EventStore.Storage,
   serializer: EventStore.TermSerializer,
   username: "postgres",


### PR DESCRIPTION
Missing `ex_unit` config prevented benchmark suite from being run.