### PR TITLE
Use Jason for JSONB decoding

### DIFF
--- a/lib/register_postgres_types.ex
+++ b/lib/register_postgres_types.ex
@@ -1,3 +1,3 @@
 if Code.ensure_loaded?(Postgrex) do
-  Postgrex.Types.define(EventStore.PostgresTypes, [], json: Poison)
+  Postgrex.Types.define(EventStore.PostgresTypes, [], json: Jason)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,8 @@ defmodule EventStore.Mixfile do
       {:ex_doc, "~> 0.19", only: :dev},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:mix_test_watch, "~> 0.9", only: :dev},
-      {:poison, "~> 2.2 or ~> 3.0 or ~> 4.0", optional: true}
+      {:poison, "~> 2.2 or ~> 3.0 or ~> 4.0", optional: true},
+      {:jason, "~> 1.1"}
     ]
   end
 


### PR DESCRIPTION
Poison is an optional dependency but Postgrex is configured to use Poison for JSONB decoding