### PR TITLE
Ensure the event store application doesn't crash when the database connection is lost

### DIFF
--- a/lib/event_store/monitored_server.ex
+++ b/lib/event_store/monitored_server.ex
@@ -85,14 +85,14 @@ defmodule EventStore.MonitoredServer do
   end
 
   @doc """
-  Handle process terminate by attempting to restart, after a delay.
+  Handle process exit by attempting to restart, after a delay.
   """
   def handle_info({:EXIT, pid, reason}, %State{pid: pid} = state) do
     %State{name: name} = state
 
     Logger.debug(fn -> "Monitored process EXIT due to: #{inspect(reason)}" end)
 
-    notify_monitors({:EXIT, name, pid, reason}, state)
+    notify_monitors({:DOWN, name, pid, reason}, state)
 
     state = %State{state | pid: nil}
 

--- a/lib/event_store/notifications/listener.ex
+++ b/lib/event_store/notifications/listener.ex
@@ -70,6 +70,14 @@ defmodule EventStore.Notifications.Listener do
     dispatch_events([], state)
   end
 
+  # Ignore notifications when database connection down.
+  def handle_info(
+        {:notification, _connection_pid, _ref, _channel, _payload},
+        %Listener{ref: nil} = state
+      ) do
+    {:noreply, [], state}
+  end
+
   def handle_demand(incoming_demand, %Listener{demand: pending_demand} = state) do
     dispatch_events([], %Listener{state | demand: incoming_demand + pending_demand})
   end

--- a/test/advisory_locks_test.exs
+++ b/test/advisory_locks_test.exs
@@ -9,10 +9,6 @@ defmodule EventStore.AdvisoryLocksTest do
 
     {:ok, conn} = Postgrex.start_link(postgrex_config)
 
-    on_exit(fn ->
-      ProcessHelper.shutdown(conn)
-    end)
-
     [
       conn: conn
     ]

--- a/test/monitored_server_test.exs
+++ b/test/monitored_server_test.exs
@@ -23,14 +23,14 @@ defmodule EventStore.MonitoredServerTest do
     end)
   end
 
-  test "should send `EXIT` message after process exit" do
+  test "should send `DOWN` message after process shutdown" do
     {:ok, _pid} = start_monitored_process()
 
-    refute_receive {:EXIT, MonitoredServer, _pid, _reason}
+    refute_receive {:DOWN, MonitoredServer, _pid, _reason}
 
-    shutdown_observed_process()
+    _pid = shutdown_observed_process()
 
-    assert_receive {:EXIT, MonitoredServer, _pid, :shutdown}
+    assert_receive {:DOWN, MonitoredServer, _pid, :shutdown}
   end
 
   test "should send `:UP` message after process restarted" do
@@ -38,7 +38,7 @@ defmodule EventStore.MonitoredServerTest do
 
     assert_receive {:UP, MonitoredServer, _pid}
 
-    shutdown_observed_process()
+    _pid = shutdown_observed_process()
 
     assert_receive {:UP, MonitoredServer, _pid}
   end


### PR DESCRIPTION
Losing a connection to the database should not stop the Event Store application. Instead, it should attempt to reconnect at a frequent interval until a database connection can be established.