### PR TITLE
SSL Support

### DIFF
--- a/lib/mix/tasks/event_store.create.ex
+++ b/lib/mix/tasks/event_store.create.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.EventStore.Create do
   @doc false
   def run(args) do
     {:ok, _} = Application.ensure_all_started(:postgrex)
+    {:ok, _} = Application.ensure_all_started(:ssl)
 
     config = Config.parsed()
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])

--- a/lib/mix/tasks/event_store.drop.ex
+++ b/lib/mix/tasks/event_store.drop.ex
@@ -16,6 +16,9 @@ defmodule Mix.Tasks.EventStore.Drop do
 
   @doc false
   def run(_args) do
+    {:ok, _} = Application.ensure_all_started(:postgrex)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
     config = Config.parsed()
 
     if skip_safety_warnings?() or

--- a/lib/mix/tasks/event_store.init.ex
+++ b/lib/mix/tasks/event_store.init.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.EventStore.Init do
   @doc false
   def run(args) do
     {:ok, _} = Application.ensure_all_started(:postgrex)
+    {:ok, _} = Application.ensure_all_started(:ssl)
 
     config = Config.parsed()
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])

--- a/lib/mix/tasks/event_store.migrate.ex
+++ b/lib/mix/tasks/event_store.migrate.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.EventStore.Migrate do
   @doc false
   def run(args) do
     {:ok, _} = Application.ensure_all_started(:postgrex)
+    {:ok, _} = Application.ensure_all_started(:ssl)
 
     config = Config.parsed()
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule EventStore.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :ssl],
       mod: {EventStore.Application, []}
     ]
   end


### PR DESCRIPTION
When running the mix tasks with a database configured to use SSL, there's an error stating that the SSL application hasn't been started. Adding it as an extra application turned out to not be enough as the mix tasks still raised this error.

More details/source of the error: elixir-ecto/postgrex#325