### PR TITLE
Fix issue with concurrent subscription partitioning

### DIFF
--- a/config/bench.exs
+++ b/config/bench.exs
@@ -3,7 +3,9 @@ use Mix.Config
 # no logging for benchmarking
 config :logger, backends: []
 
-config :ex_unit, assert_receive_timeout: 2_000
+config :ex_unit,
+  assert_receive_timeout: 2_000,
+  refute_receive_timeout: 1_000
 
 config :eventstore, EventStore.Storage,
   serializer: EventStore.TermSerializer,

--- a/config/distributed.exs
+++ b/config/distributed.exs
@@ -9,7 +9,7 @@ config :logger,
 config :ex_unit,
   capture_log: true,
   assert_receive_timeout: 10_000,
-  refute_receive_timeout: 5_000
+  refute_receive_timeout: 2_000
 
 config :eventstore, EventStore.Storage,
   serializer: EventStore.JsonSerializer,

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -4,7 +4,8 @@ config :logger, backends: []
 
 config :ex_unit,
   capture_log: true,
-  assert_receive_timeout: 2_000
+  assert_receive_timeout: 2_000,
+  refute_receive_timeout: 1_000
 
 config :eventstore, EventStore.Storage,
   serializer: EventStore.JsonbSerializer,

--- a/config/local.exs
+++ b/config/local.exs
@@ -4,7 +4,8 @@ config :logger, backends: []
 
 config :ex_unit,
   capture_log: true,
-  assert_receive_timeout: 2_000
+  assert_receive_timeout: 2_000,
+  refute_receive_timeout: 1_000
 
 config :eventstore, EventStore.Storage,
   serializer: EventStore.JsonSerializer,

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,8 @@ config :logger, backends: []
 
 config :ex_unit,
   capture_log: true,
-  assert_receive_timeout: 2_000
+  assert_receive_timeout: 2_000,
+  refute_receive_timeout: 100
 
 config :eventstore, EventStore.Storage,
   serializer: EventStore.JsonSerializer,

--- a/lib/event_store/subscriptions/subscriber.ex
+++ b/lib/event_store/subscriptions/subscriber.ex
@@ -54,7 +54,7 @@ defmodule EventStore.Subscriptions.Subscriber do
 
     case ack_event_index(in_flight, ack) do
       nil ->
-        {subscriber, []}
+        {:error, :unexpected_ack}
 
       index ->
         # All in-flight events up to the ack'd event number are also ack'd
@@ -69,7 +69,7 @@ defmodule EventStore.Subscriptions.Subscriber do
               %Subscriber{subscriber | in_flight: in_flight}
           end
 
-        {subscriber, acknowledged_events}
+        {:ok, subscriber, acknowledged_events}
     end
   end
 

--- a/lib/event_store/subscriptions/subscriber.ex
+++ b/lib/event_store/subscriptions/subscriber.ex
@@ -58,13 +58,10 @@ defmodule EventStore.Subscriptions.Subscriber do
 
       index ->
         # All in-flight events up to the ack'd event number are also ack'd
-        acknowledged_events =
-          in_flight
-          |> Enum.reverse()
-          |> Enum.take(length(in_flight) - index)
+        {in_flight, acknowledged_events} = Enum.split(in_flight, index)
 
         subscriber =
-          case in_flight -- acknowledged_events do
+          case in_flight do
             [] ->
               %Subscriber{subscriber | in_flight: [], partition_key: nil}
 
@@ -79,7 +76,7 @@ defmodule EventStore.Subscriptions.Subscriber do
   defp ack_event_index(in_flight, ack) do
     Enum.find_index(in_flight, fn
       %RecordedEvent{event_number: ^ack} -> true
-      _event -> false
+      %RecordedEvent{} -> false
     end)
   end
 end

--- a/lib/event_store/subscriptions/subscription_fsm.ex
+++ b/lib/event_store/subscriptions/subscription_fsm.ex
@@ -92,9 +92,8 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
   defstate subscribed do
     # Notify events when subscribed
     defevent notify_events(events), data: %SubscriptionState{} = data do
-      %SubscriptionState{last_received: last_received, last_sent: last_sent} = data
-      IO.inspect(last_received, label: "last_received")
-      IO.inspect(last_sent, label: "last_sent")
+      %SubscriptionState{last_received: last_received} = data
+
       expected_event = last_received + 1
 
       case first_event_number(events) do
@@ -119,7 +118,6 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
 
           # Subscriber is up-to-date, so enqueue events to send
           data = data |> enqueue_events(events) |> notify_subscribers()
-          IO.inspect(data)
 
           if over_capacity?(data) do
             # Too many pending events, must wait for these to be processed.

--- a/test/streams/all_stream_test.exs
+++ b/test/streams/all_stream_test.exs
@@ -54,10 +54,10 @@ defmodule EventStore.Streams.AllStreamTest do
         )
 
       assert_receive {:events, received_events1}
-      Subscription.ack(subscription, received_events1)
+      :ok = Subscription.ack(subscription, received_events1)
 
       assert_receive {:events, received_events2}
-      Subscription.ack(subscription, received_events2)
+      :ok = Subscription.ack(subscription, received_events2)
 
       assert length(received_events1 ++ received_events2) == 6
 
@@ -96,10 +96,10 @@ defmodule EventStore.Streams.AllStreamTest do
         )
 
       assert_receive {:events, received_events1}
-      Subscription.ack(subscription, received_events1)
+      :ok = Subscription.ack(subscription, received_events1)
 
       assert_receive {:events, received_events2}
-      Subscription.ack(subscription, received_events2)
+      :ok = Subscription.ack(subscription, received_events2)
 
       assert length(received_events1 ++ received_events2) == 4
 

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -227,12 +227,12 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert_receive {:events, received_events}
       assert pluck(received_events, :data) == pluck(initial_events, :data)
 
-      Subscription.ack(subscription, received_events)
+      :ok = Subscription.ack(subscription, received_events)
 
       assert_receive {:events, received_events}
       assert pluck(received_events, :data) == pluck(new_events, :data)
 
-      Subscription.ack(subscription, received_events)
+      :ok = Subscription.ack(subscription, received_events)
 
       refute_receive {:events, _received_events}
     end
@@ -253,12 +253,12 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert_receive {:events, received_events}
       assert pluck(received_events, :data) == pluck(initial_events, :data)
 
-      Subscription.ack(subscription, 1)
+      :ok = Subscription.ack(subscription, 1)
 
       assert_receive {:events, received_events}
       assert pluck(received_events, :data) == pluck(new_events, :data)
 
-      Subscription.ack(subscription, 2)
+      :ok = Subscription.ack(subscription, 2)
 
       refute_receive {:events, _received_events}
     end
@@ -316,7 +316,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(stream1_received_events, :metadata) == pluck(stream1_events, :metadata)
       refute pluck(stream1_received_events, :created_at) |> Enum.any?(&is_nil/1)
 
-      Subscription.ack(subscription, stream1_received_events)
+      :ok = Subscription.ack(subscription, stream1_received_events)
 
       assert_receive {:events, stream2_received_events}
       assert pluck(stream2_received_events, :event_number) == [2]
@@ -352,7 +352,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       :ok = EventStore.append_to_stream(stream2_uuid, 1, stream2_new_events)
 
       assert_receive {:events, stream1_received_events}
-      Subscription.ack(subscription, stream1_received_events)
+      :ok = Subscription.ack(subscription, stream1_received_events)
 
       assert_receive {:events, stream2_received_events}
 
@@ -393,7 +393,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(initial_received_events, :data) == pluck(initial_events, :data)
 
       # Acknowledge receipt of first event only
-      Subscription.ack(subscription, hd(initial_received_events))
+      :ok = Subscription.ack(subscription, hd(initial_received_events))
       refute_receive {:events, _events}
 
       :ok = EventStore.append_to_stream(stream_uuid, 3, remaining_events)
@@ -422,7 +422,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       :ok = EventStore.append_to_stream(stream2_uuid, 0, stream2_events)
 
       assert_receive {:events, stream1_received_events}
-      Subscription.ack(subscription, 1)
+      :ok = Subscription.ack(subscription, 1)
 
       assert_receive {:events, stream2_received_events}
 
@@ -556,7 +556,8 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert :ok = EventStore.delete_subscription(stream_uuid, subscription_name)
       refute Process.alive?(subscription)
 
-      assert {:ok, []} = EventStore.Storage.subscriptions(@conn, pool: EventStore.Config.get_pool())
+      assert {:ok, []} =
+               EventStore.Storage.subscriptions(@conn, pool: EventStore.Config.get_pool())
     end
   end
 
@@ -590,7 +591,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
     assert_receive {:events, received_events}
     assert pluck(received_events, :event_number) == expected_event_numbers
 
-    Subscription.ack(subscription, received_events)
+    :ok = Subscription.ack(subscription, received_events)
   end
 
   defp pluck(enumerable, field) do

--- a/test/subscriptions/subscription_back_pressure_test.exs
+++ b/test/subscriptions/subscription_back_pressure_test.exs
@@ -82,7 +82,7 @@ defmodule EventStore.Subscriptions.SubscriptionBackPressureTest do
       assert event.event_number == expected_event_number
     end
 
-    Subscription.ack(subscription, received_events)
+    :ok = Subscription.ack(subscription, received_events)
   end
 
   defp append_to_stream(stream_uuid, event_count) do

--- a/test/subscriptions/subscription_catch_up_test.exs
+++ b/test/subscriptions/subscription_catch_up_test.exs
@@ -69,6 +69,6 @@ defmodule EventStore.Subscriptions.SubscriptionCatchUpTest do
       assert event.stream_uuid == expected_stream_uuid
     end)
 
-    Subscription.ack(subscription, received_events)
+    :ok = Subscription.ack(subscription, received_events)
   end
 end

--- a/test/subscriptions/subscription_partitioning_test.exs
+++ b/test/subscriptions/subscription_partitioning_test.exs
@@ -265,13 +265,6 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
     end)
   end
 
-  def receive_and_ack(subscription, expected_stream_uuid) do
-    assert_receive {:events, received_events}
-    assert Enum.all?(received_events, fn event -> event.stream_uuid == expected_stream_uuid end)
-
-    Subscription.ack(subscription, received_events)
-  end
-
   defp append_to_stream(stream_uuid, event_count, expected_version \\ 0) do
     events = EventFactory.create_events(event_count)
 

--- a/test/subscriptions/subscription_partitioning_test.exs
+++ b/test/subscriptions/subscription_partitioning_test.exs
@@ -1,7 +1,10 @@
 defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
   use EventStore.StorageCase
 
-  alias EventStore.{EventFactory, RecordedEvent}
+  import EventStore.SubscriptionHelpers
+
+  alias EventStore.EventFactory
+  alias EventStore.RecordedEvent
   alias EventStore.Subscriptions.Subscription
 
   describe "subscription partitioning" do
@@ -9,9 +12,9 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
       subscription_name = UUID.uuid4()
       stream_uuid = UUID.uuid4()
 
-      subscriber1 = start_subscriber(:subscriber1)
-      subscriber2 = start_subscriber(:subscriber2)
-      subscriber3 = start_subscriber(:subscriber3)
+      subscriber1 = start_subscriber()
+      subscriber2 = start_subscriber()
+      subscriber3 = start_subscriber()
 
       partition_by = fn %RecordedEvent{data: %EventFactory.Event{event: number}} ->
         rem(number, 2)
@@ -44,14 +47,14 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
           partition_by: partition_by
         )
 
-      assert_receive {:subscribed, susbcription, :subscriber1}
-      assert_receive {:subscribed, susbcription, :subscriber2}
-      assert_receive {:subscribed, susbcription, :subscriber3}
+      assert_receive {:subscribed, ^subscription, ^subscriber1}
+      assert_receive {:subscribed, ^subscription, ^subscriber2}
+      assert_receive {:subscribed, ^subscription, ^subscriber3}
 
-      append_to_stream(stream_uuid, 9)
+      :ok = append_to_stream(stream_uuid, 9)
 
-      assert_receive_events([1, 3, 5], :subscriber1)
-      assert_receive_events([2, 4, 6], :subscriber2)
+      assert_receive_events([1, 3, 5], subscriber1)
+      assert_receive_events([2, 4, 6], subscriber2)
 
       refute_receive {:events, _received_events, _subscriber}
     end
@@ -59,9 +62,9 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
     test "should partition events by stream identity" do
       subscription_name = UUID.uuid4()
 
-      subscriber1 = start_subscriber(:subscriber1)
-      subscriber2 = start_subscriber(:subscriber2)
-      subscriber3 = start_subscriber(:subscriber3)
+      subscriber1 = start_subscriber()
+      subscriber2 = start_subscriber()
+      subscriber3 = start_subscriber()
 
       partition_by = fn %RecordedEvent{stream_uuid: stream_uuid} -> stream_uuid end
 
@@ -92,25 +95,25 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
           partition_by: partition_by
         )
 
-      assert_receive {:subscribed, susbcription, :subscriber1}
-      assert_receive {:subscribed, susbcription, :subscriber2}
-      assert_receive {:subscribed, susbcription, :subscriber3}
+      assert_receive {:subscribed, ^subscription, ^subscriber1}
+      assert_receive {:subscribed, ^subscription, ^subscriber2}
+      assert_receive {:subscribed, ^subscription, ^subscriber3}
 
-      append_to_stream("stream1", 2)
-      append_to_stream("stream2", 2)
-      append_to_stream("stream3", 2)
+      :ok = append_to_stream("stream1", 2)
+      :ok = append_to_stream("stream2", 2)
+      :ok = append_to_stream("stream3", 2)
 
-      assert_receive_events([1], :subscriber1)
-      assert_receive_events([3], :subscriber2)
-      assert_receive_events([5], :subscriber3)
+      assert_receive_events([1], subscriber1)
+      assert_receive_events([3], subscriber2)
+      assert_receive_events([5], subscriber3)
 
-      Subscription.ack(subscription, 1, subscriber1)
-      Subscription.ack(subscription, 3, subscriber2)
-      Subscription.ack(subscription, 5, subscriber3)
+      :ok = Subscription.ack(subscription, 1, subscriber1)
+      :ok = Subscription.ack(subscription, 3, subscriber2)
+      :ok = Subscription.ack(subscription, 5, subscriber3)
 
-      assert_receive_events([2], :subscriber1)
-      assert_receive_events([4], :subscriber2)
-      assert_receive_events([6], :subscriber3)
+      assert_receive_events([2], subscriber1)
+      assert_receive_events([4], subscriber2)
+      assert_receive_events([6], subscriber3)
 
       refute_receive {:events, _received_events, _subscriber}
     end
@@ -119,9 +122,9 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
       subscription_name = UUID.uuid4()
       stream_uuid = UUID.uuid4()
 
-      subscriber1 = start_subscriber(:subscriber1)
-      subscriber2 = start_subscriber(:subscriber2)
-      subscriber3 = start_subscriber(:subscriber3)
+      subscriber1 = start_subscriber()
+      subscriber2 = start_subscriber()
+      subscriber3 = start_subscriber()
 
       partition_by = fn %RecordedEvent{data: %EventFactory.Event{event: number}} ->
         rem(number, 3)
@@ -154,32 +157,32 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
           partition_by: partition_by
         )
 
-      append_to_stream(stream_uuid, 9)
+      :ok = append_to_stream(stream_uuid, 9)
 
-      assert_receive_events([1, 4], :subscriber1)
-      assert_receive_events([2, 5], :subscriber2)
-      assert_receive_events([3, 6], :subscriber3)
+      assert_receive_events([1, 4], subscriber1)
+      assert_receive_events([2, 5], subscriber2)
+      assert_receive_events([3, 6], subscriber3)
 
-      Subscription.ack(subscription, 4, subscriber1)
-      assert_receive_events([7], :subscriber1)
+      :ok = Subscription.ack(subscription, 4, subscriber1)
+      assert_receive_events([7], subscriber1)
 
-      Subscription.ack(subscription, 7, subscriber1)
-      refute_receive {:events, _events, :subscriber1}
+      :ok = Subscription.ack(subscription, 7, subscriber1)
+      refute_receive {:events, _events, ^subscriber1}
 
-      Subscription.ack(subscription, 5, subscriber2)
-      assert_receive_events([8], :subscriber2)
+      :ok = Subscription.ack(subscription, 5, subscriber2)
+      assert_receive_events([8], subscriber2)
 
-      Subscription.ack(subscription, 6, subscriber3)
-      assert_receive_events([9], :subscriber3)
+      :ok = Subscription.ack(subscription, 6, subscriber3)
+      assert_receive_events([9], subscriber3)
     end
 
     test "should redistribute partitioned events after all in-flight events acknowledged and another subscriber available" do
       subscription_name = UUID.uuid4()
       stream_uuid = UUID.uuid4()
 
-      subscriber1 = start_subscriber(:subscriber1)
-      subscriber2 = start_subscriber(:subscriber2)
-      subscriber3 = start_subscriber(:subscriber3)
+      subscriber1 = start_subscriber()
+      subscriber2 = start_subscriber()
+      subscriber3 = start_subscriber()
 
       partition_by = fn %RecordedEvent{data: %EventFactory.Event{event: number}} ->
         rem(number, 4)
@@ -203,13 +206,13 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
           partition_by: partition_by
         )
 
-      append_to_stream(stream_uuid, 16)
+      :ok = append_to_stream(stream_uuid, 16)
 
-      assert_receive_events([1, 5], :subscriber1)
-      assert_receive_events([2, 6], :subscriber2)
+      assert_receive_events([1, 5], subscriber1)
+      assert_receive_events([2, 6], subscriber2)
 
-      Subscription.ack(subscription, 5, subscriber1)
-      assert_receive_events([3, 7], :subscriber1)
+      :ok = Subscription.ack(subscription, 5, subscriber1)
+      assert_receive_events([3, 7], subscriber1)
 
       {:ok, ^subscription} =
         EventStore.subscribe_to_all_streams(
@@ -220,54 +223,21 @@ defmodule EventStore.Subscriptions.SubscriptionPartitioningTest do
           partition_by: partition_by
         )
 
-      assert_receive_events([4, 8], :subscriber3)
-      Subscription.ack(subscription, 8, subscriber3)
+      assert_receive_events([4, 8], subscriber3)
+      :ok = Subscription.ack(subscription, 8, subscriber3)
 
-      assert_receive_events([9, 13], :subscriber3)
-      Subscription.ack(subscription, 13, subscriber3)
+      assert_receive_events([9, 13], subscriber3)
+      :ok = Subscription.ack(subscription, 13, subscriber3)
 
-      assert_receive_events([12, 16], :subscriber3)
-      Subscription.ack(subscription, 16, subscriber3)
-      refute_receive {:events, _events, :subscriber3}
+      assert_receive_events([12, 16], subscriber3)
+      :ok = Subscription.ack(subscription, 16, subscriber3)
+      refute_receive {:events, _events, ^subscriber3}
 
-      Subscription.ack(subscription, 7, subscriber1)
-      assert_receive_events([11, 15], :subscriber1)
+      :ok = Subscription.ack(subscription, 7, subscriber1)
+      assert_receive_events([11, 15], subscriber1)
 
-      Subscription.ack(subscription, 6, subscriber2)
-      assert_receive_events([10, 14], :subscriber2)
+      :ok = Subscription.ack(subscription, 6, subscriber2)
+      assert_receive_events([10, 14], subscriber2)
     end
-  end
-
-  defp assert_receive_events(expected_event_numbers, expected_subscriber) do
-    assert_receive {:events, received_events, ^expected_subscriber}
-
-    actual_event_numbers = Enum.map(received_events, & &1.event_number)
-    assert expected_event_numbers == actual_event_numbers
-  end
-
-  defp start_subscriber(name) do
-    reply_to = self()
-
-    spawn_link(fn ->
-      receive_events = fn loop ->
-        receive do
-          {:subscribed, subscription} ->
-            send(reply_to, {:subscribed, subscription, name})
-
-          {:events, events} ->
-            send(reply_to, {:events, events, name})
-        end
-
-        loop.(loop)
-      end
-
-      receive_events.(receive_events)
-    end)
-  end
-
-  defp append_to_stream(stream_uuid, event_count, expected_version \\ 0) do
-    events = EventFactory.create_events(event_count)
-
-    :ok = EventStore.append_to_stream(stream_uuid, expected_version, events)
   end
 end

--- a/test/subscriptions/subscription_recovery_test.exs
+++ b/test/subscriptions/subscription_recovery_test.exs
@@ -104,7 +104,7 @@ defmodule EventStore.Subscriptions.SubscriptionRecoveryTest do
       assert event.stream_uuid == expected_stream_uuid
     end)
 
-    Subscription.ack(subscription, received_events)
+    :ok = Subscription.ack(subscription, received_events)
   end
 
   def wait_until(timeout \\ 1000, step \\ 50, fun)

--- a/test/support/collecting_subscriber.ex
+++ b/test/support/collecting_subscriber.ex
@@ -51,7 +51,7 @@ defmodule EventStore.Support.CollectingSubscriber do
   def handle_info({:events, received_events}, state) do
     %{events: events, subscription: subscription} = state
 
-    Subscription.ack(subscription, received_events)
+    :ok = Subscription.ack(subscription, received_events)
 
     {:noreply, %{state | events: events ++ received_events}}
   end


### PR DESCRIPTION
Ensure events are distributed to subscribers by partition key.
Ensure each acknowledged event is an expected in-flight event during subscription ack.