### PR TITLE
Reliably start Notifications supervisor on global name clash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ cache:
   - priv/plts
 
 elixir:
-  - 1.8.0
+  - 1.8.1
 
 otp_release:
-  - 21.2
+  - 21.3
 
 services:
   - postgresql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fix issue with concurrent subscription partitioning ([#162](https://github.com/commanded/eventstore/pull/162)).
+- Reliably start `EventStore.Notifications.Supervisor` on `:global` name clash ([#165](https://github.com/commanded/eventstore/pull/165)).
 
 ## v0.16.1
 

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -12,12 +12,7 @@ defmodule EventStore.Notifications.Supervisor do
   use Supervisor
 
   alias EventStore.{Config, MonitoredServer}
-
-  alias EventStore.Notifications.{
-    Listener,
-    Reader,
-    StreamBroadcaster
-  }
+  alias EventStore.Notifications.{Listener, Reader, StreamBroadcaster}
 
   @doc """
   Starts a globally named supervisor process.
@@ -29,6 +24,11 @@ defmodule EventStore.Notifications.Supervisor do
     case Supervisor.start_link(__MODULE__, config, name: {:global, __MODULE__}) do
       {:ok, pid} ->
         {:ok, pid}
+
+      {:error, :killed} ->
+        # Process may be killed due to `:global` name registation when another node connects.
+        # Attempting to start again should link to the other named existing process.
+        start_link(config)
 
       {:error, {:already_started, pid}} ->
         Process.link(pid)

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -34,8 +34,8 @@ defmodule EventStore.Notifications.Supervisor do
         Process.link(pid)
         {:ok, pid}
 
-      :ignore ->
-        :ignore
+      reply ->
+        reply
     end
   end
 

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -26,7 +26,7 @@ defmodule EventStore.Subscriptions do
     do_unsubscribe_from_stream(@all_stream, subscription_name)
   end
 
-  def delete_subscription(conn, stream_uuid, subscription_name, opts) do
+  def delete_subscription(conn, stream_uuid, subscription_name, opts \\ []) do
     :ok = Subscriptions.Supervisor.shutdown_subscription(stream_uuid, subscription_name)
 
     Storage.delete_subscription(conn, stream_uuid, subscription_name, opts)

--- a/lib/event_store/subscriptions/subscription_fsm.ex
+++ b/lib/event_store/subscriptions/subscription_fsm.ex
@@ -265,8 +265,7 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
       conn,
       stream_uuid,
       subscription_name,
-      start_from,
-      pool: EventStore.Config.get_pool()
+      start_from
     )
   end
 
@@ -398,8 +397,7 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
       conn,
       stream_uuid,
       last_sent + 1,
-      max_size,
-      pool: EventStore.Config.get_pool()
+      max_size
     )
   end
 
@@ -610,13 +608,7 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
         |> checkpoint_last_seen(true)
 
       persist ->
-        Storage.Subscription.ack_last_seen_event(
-          conn,
-          stream_uuid,
-          subscription_name,
-          last_ack,
-          pool: EventStore.Config.get_pool()
-        )
+        Storage.Subscription.ack_last_seen_event(conn, stream_uuid, subscription_name, last_ack)
 
         data
 

--- a/lib/event_store/tasks/init.ex
+++ b/lib/event_store/tasks/init.ex
@@ -28,16 +28,16 @@ defmodule EventStore.Tasks.Init do
   """
   def exec(config, opts) do
     opts = Keyword.merge([is_mix: false, quiet: false], opts)
-    conn_opts = [pool: EventStore.Config.get_pool()]
 
     {:ok, conn} = Postgrex.start_link(config)
 
-    case run_query(conn, @is_events_table_exists, conn_opts) do
+    case run_query!(conn, @is_events_table_exists) do
       %{rows: [[true]]} ->
         write_info("The EventStore database has already been initialized.", opts)
 
       %{rows: [[false]]} ->
-        Initializer.run!(conn, conn_opts)
+        Initializer.run!(conn)
+
         write_info("The EventStore database has been initialized.", opts)
     end
 
@@ -47,7 +47,7 @@ defmodule EventStore.Tasks.Init do
     :ok
   end
 
-  defp run_query(conn, query, opts) do
-    Postgrex.query!(conn, query, [], opts)
+  defp run_query!(conn, query) do
+    Postgrex.query!(conn, query, [])
   end
 end

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -90,7 +90,7 @@ defmodule EventStore.Tasks.Migrate do
   defp run_query(config, query) do
     {:ok, conn} = Postgrex.start_link(config)
 
-    reply = Postgrex.query!(conn, query, [], pool: EventStore.Config.get_pool())
+    reply = Postgrex.query!(conn, query, [])
 
     true = Process.unlink(conn)
     true = Process.exit(conn, :shutdown)

--- a/test/notifications/supervisor_test.exs
+++ b/test/notifications/supervisor_test.exs
@@ -1,0 +1,35 @@
+defmodule EventStore.Notifications.SupervisorTest do
+  use ExUnit.Case
+
+  alias EventStore.Config
+
+  setup_all do
+    Application.stop(:eventstore)
+
+    on_exit(fn ->
+      {:ok, _} = Application.ensure_all_started(:eventstore)
+    end)
+  end
+
+  test "should succeed when globally named supervisor process killed during `start_link/1`" do
+    spawn_link(&kill_notifications_supervisor/0)
+
+    {:ok, _pid} =
+      Supervisor.start_link(
+        [
+          {EventStore.Notifications.Supervisor, Config.parsed()}
+        ],
+        strategy: :one_for_one
+      )
+  end
+
+  defp kill_notifications_supervisor do
+    case :global.whereis_name(EventStore.Notifications.Supervisor) do
+      pid when is_pid(pid) ->
+        Process.exit(pid, :kill)
+
+      :undefined ->
+        kill_notifications_supervisor()
+    end
+  end
+end

--- a/test/notifications/supervisor_test.exs
+++ b/test/notifications/supervisor_test.exs
@@ -3,7 +3,7 @@ defmodule EventStore.Notifications.SupervisorTest do
 
   alias EventStore.Config
 
-  setup_all do
+  setup do
     Application.stop(:eventstore)
 
     on_exit(fn ->

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -556,8 +556,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert :ok = EventStore.delete_subscription(stream_uuid, subscription_name)
       refute Process.alive?(subscription)
 
-      assert {:ok, []} =
-               EventStore.Storage.subscriptions(@conn, pool: EventStore.Config.get_pool())
+      assert {:ok, []} = EventStore.Storage.subscriptions(@conn)
     end
   end
 

--- a/test/subscriptions/subscription_locking_test.exs
+++ b/test/subscriptions/subscription_locking_test.exs
@@ -73,13 +73,7 @@ defmodule EventStore.Subscriptions.SubscriptionLockingTest do
       :ok = disconnect(subscription)
 
       :ok =
-        EventStore.Storage.Subscription.ack_last_seen_event(
-          @conn,
-          "$all",
-          subscription_name,
-          2,
-          pool: EventStore.Config.get_pool()
-        )
+        EventStore.Storage.Subscription.ack_last_seen_event(@conn, "$all", subscription_name, 2)
 
       :ok = reconnect(subscription)
 

--- a/test/support/storage_case.ex
+++ b/test/support/storage_case.ex
@@ -2,6 +2,7 @@ defmodule EventStore.StorageCase do
   use ExUnit.CaseTemplate
 
   alias EventStore.Config
+  alias EventStore.Storage
 
   setup_all do
     config = Config.parsed()
@@ -15,7 +16,7 @@ defmodule EventStore.StorageCase do
   setup %{conn: conn} do
     registry = Application.get_env(:eventstore, :registry, :local)
 
-    EventStore.Storage.Initializer.reset!(conn)
+    Storage.Initializer.reset!(conn)
 
     after_reset(registry)
 


### PR DESCRIPTION
The `Notifications.Supervisor` process is started with a globally registered process name to ensure only one instance runs within a cluster of nodes when run using distributed Erlang. Only a single database listener process is needed to run because it broadcasts events to processes running on all connected nodes.

However, when the same named global processes exist when two nodes are connected one process will be killed. If this occurs during proess start then the error returned from `start_link` is `{:error, :killed}`. This error is not being handled, causing the entire event store application to crash.

The pull request ensures than when an `{:error, :killed}` value is returned the supervisor process is started again, locating the existing named process and linking to it.

Fixes #164.