### PR TITLE
Add support to queue_target and queue_interval

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -38,12 +38,19 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
         url: "postgres://postgres:postgres@localhost/eventstore",
         pool_size: 10
         pool_overflow: 5
+        queue_target: 5_000
+        queue_interval: 10_000
       ```
 
   The database connection pool configuration options are:
 
   - `:pool_size` - The number of connections (default: `10`).
   - `:pool_overflow` - The maximum number of overflow connections to start if all connections are checked out (default: `0`).
+  
+  Handling requests is done through a queue. When DBConnection is started, there are two relevant options to control the queue:
+  
+  - `:queue_target` - in milliseconds (default: `50`).
+  - `:queue_interval` - in milliseconds (default: `1000`).
 
   4. Add your event store module to the `event_stores` list for your app in mix config:
 

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -163,7 +163,9 @@ defmodule EventStore.Config do
 
     [
       pool_size: 10,
-      pool_overflow: 0
+      pool_overflow: 0,
+      queue_target: 5_000,
+      queue_interval: 10_000
     ]
     |> Keyword.merge(config)
     |> Keyword.take(
@@ -171,7 +173,9 @@ defmodule EventStore.Config do
         [
           :pool,
           :pool_size,
-          :pool_overflow
+          :pool_overflow,
+          :queue_target,
+          :queue_interval
         ]
     )
     |> Keyword.put(:backoff_type, :exp)

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -3,7 +3,7 @@ defmodule EventStore.Config do
   Provides access to the EventStore configuration.
   """
 
-  @integer_url_query_params ["pool_size"]
+  @integer_url_query_params ["pool_size", "queue_target", "queue_interval"]
 
   @doc """
   Get the event store configuration for the environment.


### PR DESCRIPTION
To solve an issue related with `connection not available and request was dropped from queue after 1652ms`.

```
11:33:16.904 [error] GenServer {EventStore.Subscriptions.Subscription, {"$all", "Account.Workflows.GPEmailInvitationLogic"}} terminating
     ** (Protocol.UndefinedError) protocol String.Chars not implemented for %DBConnection.ConnectionError{message: "connection not available and request was dropped from queue after 1652ms. You can configure how long requests wait in the queue using :queue_target and :queue_interval. See DBConnection.start_link/2 for more information", severity: :error} of type DBConnection.ConnectionError (a struct). This protocol is implemented for the following type(s): Postgrex.Query, Postgrex.Copy, Decimal, Atom, BitString, Date, NaiveDateTime, Version.Requirement, URI, DateTime, Float, Integer, List, Time, Version
         (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
         (elixir) lib/string/chars.ex:22: String.Chars.to_string/1
         (eventstore) lib/event_store/storage/subscription.ex:169: anonymous fn/3 in EventStore.Storage.Subscription.Ack.handle_response/3
         (logger) lib/logger.ex:862: Logger.normalize_message/2
         (logger) lib/logger.ex:687: Logger.__do_log__/3
         (eventstore) lib/event_store/storage/subscription.ex:168: EventStore.Storage.Subscription.Ack.handle_response/3
         (eventstore) lib/event_store/subscriptions/subscription_fsm.ex:611: EventStore.Subscriptions.SubscriptionFsm.checkpoint_last_seen/2
         (eventstore) lib/event_store/subscriptions/subscription_fsm.ex:577: EventStore.Subscriptions.SubscriptionFsm.ack_events/3
         (eventstore) lib/event_store/subscriptions/subscription_fsm.ex:135: EventStore.Subscriptions.SubscriptionFsm.transition/3
         (eventstore) lib/event_store/subscriptions/subscription.ex:162: EventStore.Subscriptions.Subscription.handle_call/3
         (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
         (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
         (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
     Last message (from #PID<0.3908.0>): {:ack, 3, #PID<0.3908.0>}
```

I did a pull request in order to support the `queue_target` and `queue_interval` options.