### PR TITLE
Allow consumption of the raw JSON of events.

### DIFF
--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -59,7 +59,7 @@ defmodule EventStore.RecordedEvent do
     %RecordedEvent{data: data, metadata: metadata, event_type: event_type} = recorded_event
 
     data =
-      case Application.get_env(:eventstore, :deserialize_event, true) do
+      case Application.get_env(:eventstore, :deserialize_events, true) do
         true -> serializer.deserialize(data, type: event_type)
         false -> data
       end

--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -60,8 +60,14 @@ defmodule EventStore.RecordedEvent do
 
     data =
       case Application.get_env(:eventstore, :deserialize_events, true) do
-        true -> serializer.deserialize(data, type: event_type)
-        false -> data
+        true ->
+          serializer.deserialize(data, type: event_type)
+
+        false ->
+          data
+
+        _ ->
+          raise ":eventstore, :deserialize_events must be a valid boolean value. (ie true or false)"
       end
 
     %RecordedEvent{

--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -58,9 +58,15 @@ defmodule EventStore.RecordedEvent do
   def deserialize(%RecordedEvent{} = recorded_event, serializer) do
     %RecordedEvent{data: data, metadata: metadata, event_type: event_type} = recorded_event
 
+    data =
+      case Application.get_env(:eventstore, :deserialize_event, true) do
+        true -> serializer.deserialize(data, type: event_type)
+        false -> data
+      end
+
     %RecordedEvent{
       recorded_event
-      | data: serializer.deserialize(data, type: event_type),
+      | data: data,
         metadata: serializer.deserialize(metadata, [])
     }
   end


### PR DESCRIPTION
Sometimes a consumer does not have access to the original structs but still needs to consume a stream.

Do not merge yet. I need to update the documentation.