### PR TITLE
Add support for `created_at` values to be of type NaiveDateTime.

### DIFF
--- a/lib/event_store/storage/reader.ex
+++ b/lib/event_store/storage/reader.ex
@@ -71,6 +71,10 @@ defmodule EventStore.Storage.Reader do
 
     defp from_timestamp(%DateTime{} = timestamp), do: timestamp
 
+    defp from_timestamp(%NaiveDateTime{} = timestamp) do
+      timestamp |> DateTime.from_naive("Etc/UTC")
+    end
+
     if Code.ensure_loaded?(Postgrex.Timestamp) do
       defp from_timestamp(%Postgrex.Timestamp{} = timestamp) do
         %Postgrex.Timestamp{


### PR DESCRIPTION
NaiveDateTime support was removed in #150. This is fine for new apps and, if running the migration, updating existing apps.

However, one scenario was not thought through and that is one where there are many consumers of the event store.

Say I have my main ES application that is running just fine with `eventstore 0.17`. But my collegue wishes to subscribe to events from a different application. He tries to use `v0.17` but it is incompatible with `DBConnection 2.0`, so he changes the `eventstore` dependency to use the master branch. Because the original application is still using `NaiveDateTime` as the timestamp, the new application crashes with `no function clause matching in EventStore.Storage.Reader.EventAdapter.from_timestamp/1`.

It is very easy to support both scenarios going forward. And this is my attempt at solving this issue.