### PR TITLE
Support Postgres schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ The purpose of the benchmark suite is to measure the performance impact of propo
 
 The benchmark suite is configured to use Erlang's [external term format](http://erlang.org/doc/apps/erts/erl_ext_dist.html) serialization. Using another serialization format, such as JSON, will likely have a negative impact on performance.
 
+## Testing
+
+Create and initialize the test event store databases:
+
+```
+MIX_ENV=test mix event_store.setup
+```
+
+Run the test suite:
+
+```
+mix test
+```
+
 ## Contributing
 
 Pull requests to contribute new or improved features, and extend documentation are most welcome.

--- a/config/bench.exs
+++ b/config/bench.exs
@@ -7,7 +7,7 @@ config :ex_unit,
   assert_receive_timeout: 2_000,
   refute_receive_timeout: 1_000
 
-config :eventstore, TestEventStore,
+default_config = [
   username: "postgres",
   password: "postgres",
   database: "eventstore_bench",
@@ -15,14 +15,10 @@ config :eventstore, TestEventStore,
   pool_size: 10,
   pool_overflow: 5,
   serializer: EventStore.TermSerializer
+]
 
-config :eventstore, SecondEventStore,
-  username: "postgres",
-  password: "postgres",
-  database: "eventstore_test_2",
-  hostname: "localhost",
-  pool_size: 1,
-  pool_overflow: 0,
-  serializer: EventStore.TermSerializer
+config :eventstore, TestEventStore, default_config
+config :eventstore, SchemaEventStore, default_config
+config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "eventstore_test_2")
 
 config :eventstore, event_stores: [TestEventStore]

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -7,7 +7,7 @@ config :ex_unit,
   assert_receive_timeout: 2_000,
   refute_receive_timeout: 100
 
-config :eventstore, TestEventStore,
+default_config = [
   column_data_type: "jsonb",
   username: "postgres",
   password: "postgres",
@@ -19,18 +19,14 @@ config :eventstore, TestEventStore,
   serializer: EventStore.JsonbSerializer,
   subscription_retry_interval: 1_000,
   types: EventStore.PostgresTypes
+]
 
-config :eventstore, SecondEventStore,
-  column_data_type: "jsonb",
-  username: "postgres",
-  password: "postgres",
-  database: "eventstore_jsonb_test_2",
-  hostname: "localhost",
-  pool_size: 1,
-  pool_overflow: 0,
-  registry: :local,
-  serializer: EventStore.JsonbSerializer,
-  subscription_retry_interval: 1_000,
-  types: EventStore.PostgresTypes
+config :eventstore, TestEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore]
+config :eventstore,
+       SecondEventStore,
+       Keyword.put(default_config, :database, "eventstore_jsonb_test_2")
+
+config :eventstore, SchemaEventStore, default_config
+
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore]

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,7 @@ config :ex_unit,
   assert_receive_timeout: 2_000,
   refute_receive_timeout: 100
 
-config :eventstore, TestEventStore,
+default_config = [
   username: "postgres",
   password: "postgres",
   database: "eventstore_test",
@@ -17,16 +17,10 @@ config :eventstore, TestEventStore,
   registry: :local,
   serializer: EventStore.JsonSerializer,
   subscription_retry_interval: 1_000
+]
 
-config :eventstore, SecondEventStore,
-  username: "postgres",
-  password: "postgres",
-  database: "eventstore_test_2",
-  hostname: "localhost",
-  pool_size: 1,
-  pool_overflow: 0,
-  registry: :local,
-  serializer: EventStore.JsonSerializer,
-  subscription_retry_interval: 1_000
+config :eventstore, TestEventStore, default_config
+config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "eventstore_test_2")
+config :eventstore, SchemaEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore]
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore]

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -150,6 +150,29 @@ defmodule MyApp.ReleaseTasks do
 end
 ```
 
+## Using Postgres schemas
+
+A Postgres database contains one or more [named schemas](https://www.postgresql.org/docs/current/ddl-schemas.html), which in turn contain tables. By default tables are defined in a schema named "public".
+
+An EventStore an be configured to use a different schema name. Specify the schema when using the `EventStore` macro in your event store module:
+
+```elixir
+defmodule MyApp.EventStore do
+  use EventStore, otp_app: :my_app, schema: "example"
+end
+```
+
+Or define it in environment config when configuring the database connection settings:
+
+```elixir
+# config/config.exs
+config :my_app, MyApp.EventStore, schema: "example"
+```
+
+This feature allows you to define and start multiple event stores sharing a single Postgres database, but with their data isolated and segregated by schema.
+
+Note the `mix event_store.<task>` tasks to create, initialize, and drop an event store database will also handle creating and/or dropping the schema.
+
 ## Event data and metadata data type
 
 EventStore has support for persisting event data and metadata as either:

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -121,6 +121,7 @@ defmodule EventStore do
       end
 
       def start_link(opts \\ []) do
+        opts = Keyword.merge(unquote(opts), opts)
         EventStore.Supervisor.start_link(__MODULE__, @otp_app, @serializer, @registry, opts)
       end
 

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -106,7 +106,8 @@ defmodule EventStore do
       @conn Module.concat([__MODULE__, EventStore.Postgrex])
 
       def config do
-        with {:ok, config} <- EventStore.Supervisor.runtime_config(__MODULE__, @otp_app, []) do
+        with {:ok, config} <-
+               EventStore.Supervisor.runtime_config(__MODULE__, @otp_app, unquote(opts)) do
           config
         end
       end

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -45,6 +45,8 @@ defmodule EventStore.Notifications.Supervisor do
 
   @impl Supervisor
   def init({event_store, registry, serializer, config}) do
+    schema = Keyword.fetch!(config, :schema)
+
     postgrex_config = Config.sync_connect_postgrex_opts(config)
 
     listener_name = Module.concat([event_store, Listener])
@@ -66,7 +68,7 @@ defmodule EventStore.Notifications.Supervisor do
            mfa: {Postgrex, :start_link, [postgrex_config]}, name: postgrex_reader_name},
           id: Module.concat([postgrex_reader_name, MonitoredServer])
         ),
-        {Listener, listen_to: postgrex_listener_name, name: listener_name},
+        {Listener, listen_to: postgrex_listener_name, schema: schema, name: listener_name},
         {Reader,
          conn: postgrex_reader_name,
          serializer: serializer,

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -229,7 +229,7 @@ defmodule EventStore.Sql.Statements do
   defp record_event_store_schema_version do
     """
     INSERT INTO schema_migrations (major_version, minor_version, patch_version)
-    VALUES (0, 17, 0);
+    VALUES (1, 1, 0);
     """
   end
 

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -148,6 +148,7 @@ defmodule EventStore.Sql.Statements do
     CREATE OR REPLACE FUNCTION notify_events()
       RETURNS trigger AS $$
     DECLARE
+      channel text;
       payload text;
     BEGIN
         -- Payload text contains:
@@ -157,10 +158,11 @@ defmodule EventStore.Sql.Statements do
         --  * last `stream_version`
         -- Each separated by a comma (e.g. 'stream-12345,1,1,5')
 
+        channel := TG_TABLE_SCHEMA || '.events';
         payload := NEW.stream_uuid || ',' || NEW.stream_id || ',' || (OLD.stream_version + 1) || ',' || NEW.stream_version;
 
         -- Notify events to listeners
-        PERFORM pg_notify('events', payload);
+        PERFORM pg_notify(channel, payload);
 
         RETURN NULL;
     END;

--- a/lib/event_store/storage/database.ex
+++ b/lib/event_store/storage/database.ex
@@ -7,15 +7,12 @@ defmodule EventStore.Storage.Database do
 
   def drop(config), do: storage_down(config)
 
-  def migrate(opts, migration) do
+  def execute(sql, opts) do
     opts = Keyword.put(opts, :timeout, :infinity)
 
-    case run_query(migration, opts) do
-      {:ok, _} ->
-        :ok
-
-      {:error, error} ->
-        {:error, Exception.message(error)}
+    case run_query(sql, opts) do
+      {:ok, _} -> :ok
+      {:error, _error} = reply -> reply
     end
   end
 
@@ -72,7 +69,8 @@ defmodule EventStore.Storage.Database do
   # Taken from ecto/adapters/postgres.ex
   defp storage_up(opts) do
     database =
-      Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
+      Keyword.fetch!(opts, :database) ||
+        raise ":database is nil in repository configuration"
 
     encoding = opts[:encoding] || "UTF8"
     opts = Keyword.put(opts, :database, "postgres")

--- a/lib/event_store/storage/schema.ex
+++ b/lib/event_store/storage/schema.ex
@@ -1,0 +1,35 @@
+defmodule EventStore.Storage.Schema do
+  @moduledoc false
+
+  alias EventStore.Storage.Database
+
+  def create(config) do
+    schema = Keyword.fetch!(config, :schema)
+
+    case Database.execute("CREATE SCHEMA #{schema}", config) do
+      :ok ->
+        :ok
+
+      {:error, %{postgres: %{code: :duplicate_schema}}} ->
+        {:error, :already_up}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+
+  def drop(config) do
+    schema = Keyword.fetch!(config, :schema)
+
+    case Database.execute("DROP SCHEMA #{schema} CASCADE;", config) do
+      :ok ->
+        :ok
+
+      {:error, %{postgres: %{code: :invalid_schema_name}}} ->
+        {:error, :already_down}
+
+      {:error, error} ->
+        {:error, Exception.message(error)}
+    end
+  end
+end

--- a/lib/event_store/tasks/create.ex
+++ b/lib/event_store/tasks/create.ex
@@ -3,16 +3,20 @@ defmodule EventStore.Tasks.Create do
   Task to create the EventStore
   """
 
-  alias EventStore.Storage.Database
   import EventStore.Tasks.Output
 
+  alias EventStore.Storage.Database
+  alias EventStore.Storage.Schema
+
   @doc """
-  Runs task
+  Runs database and schema create task.
 
   ## Parameters
+
   - config: the parsed EventStore config
 
   ## Opts
+
   - is_mix: set to `true` if running as part of a Mix task
   - quiet: set to `true` to silence output
 
@@ -30,6 +34,20 @@ defmodule EventStore.Tasks.Create do
       {:error, term} ->
         raise_msg(
           "The EventStore database couldn't be created, reason given: #{inspect(term)}.",
+          opts
+        )
+    end
+
+    case Schema.create(config) do
+      :ok ->
+        write_info("The EventStore schema has been created.", opts)
+
+      {:error, :already_up} ->
+        write_info("The EventStore schema already exists.", opts)
+
+      {:error, term} ->
+        raise_msg(
+          "The EventStore schema couldn't be created, reason given: #{inspect(term)}.",
           opts
         )
     end

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -9,7 +9,8 @@ defmodule EventStore.Tasks.Migrate do
   @available_migrations [
     "0.13.0",
     "0.14.0",
-    "0.17.0"
+    "0.17.0",
+    "1.1.0"
   ]
 
   @dialyzer {:no_return, exec: 2, handle_response: 1}

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -1,6 +1,6 @@
 defmodule EventStore.Tasks.Migrate do
   @moduledoc """
-    Task to migrate EventStore
+  Task to migrate EventStore
   """
 
   alias EventStore.Storage.Database
@@ -56,13 +56,15 @@ defmodule EventStore.Tasks.Migrate do
       path = Application.app_dir(:eventstore, "priv/event_store/migrations/v#{migration}.sql")
       script = File.read!(path)
 
-      case Database.migrate(config, script) do
+      case Database.execute(script, config) do
         :ok ->
           :ok
 
-        {:error, term} ->
+        {:error, error} ->
           raise_msg(
-            "The EventStore database couldn't be migrated, reason given: #{inspect(term)}.",
+            "The EventStore database couldn't be migrated, reason given: #{
+              inspect(Exception.message(error))
+            }.",
             opts
           )
       end

--- a/priv/event_store/migrations/v1.1.0.sql
+++ b/priv/event_store/migrations/v1.1.0.sql
@@ -2,7 +2,7 @@ DO $$
 BEGIN
 
   CREATE OR REPLACE FUNCTION notify_events()
-    RETURNS trigger AS $$
+    RETURNS trigger AS $func$
   DECLARE
     channel text;
     payload text;
@@ -22,7 +22,7 @@ BEGIN
 
       RETURN NULL;
   END;
-  $$ LANGUAGE plpgsql;
+  $func$ LANGUAGE plpgsql;
 
   -- Record schema migration
   INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (1, 1, 0);

--- a/priv/event_store/migrations/v1.1.0.sql
+++ b/priv/event_store/migrations/v1.1.0.sql
@@ -1,0 +1,31 @@
+DO $$
+BEGIN
+
+  CREATE OR REPLACE FUNCTION notify_events()
+    RETURNS trigger AS $$
+  DECLARE
+    channel text;
+    payload text;
+  BEGIN
+      -- Payload text contains:
+      --  * `stream_uuid`
+      --  * `stream_id`
+      --  * first `stream_version`
+      --  * last `stream_version`
+      -- Each separated by a comma (e.g. 'stream-12345,1,1,5')
+
+      channel := TG_TABLE_SCHEMA || '.events';
+      payload := NEW.stream_uuid || ',' || NEW.stream_id || ',' || (OLD.stream_version + 1) || ',' || NEW.stream_version;
+
+      -- Notify events to listeners
+      PERFORM pg_notify(channel, payload);
+
+      RETURN NULL;
+  END;
+  $$ LANGUAGE plpgsql;
+
+  -- Record schema migration
+  INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (1, 1, 0);
+
+END;
+$$ LANGUAGE plpgsql;

--- a/test/advisory_locks_test.exs
+++ b/test/advisory_locks_test.exs
@@ -75,6 +75,31 @@ defmodule EventStore.AdvisoryLocksTest do
     end
   end
 
+  describe "acquire same lock on different schemas" do
+    setup do
+      postgrex_config = Config.parsed(TestEventStore, :eventstore)
+
+      {:ok, conn1} =
+        postgrex_config
+        |> Keyword.put(:schema, "public")
+        |> Config.default_postgrex_opts()
+        |> Postgrex.start_link()
+
+      {:ok, conn2} =
+        postgrex_config
+        |> Keyword.put(:schema, "example")
+        |> Config.default_postgrex_opts()
+        |> Postgrex.start_link()
+
+      [conn1: conn1, conn2: conn2]
+    end
+
+    test "should acquire lock", %{conn1: conn1, conn2: conn2} do
+      :ok = Storage.Lock.try_acquire_exclusive_lock(conn1, 1)
+      :ok = Storage.Lock.try_acquire_exclusive_lock(conn2, 1)
+    end
+  end
+
   defp connection_down do
     send(@locks, {:DOWN, @conn, nil, :shutdown})
   end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -4,25 +4,28 @@ defmodule EventStore.ConfigTest do
   alias EventStore.Config
 
   test "parse keys" do
-    original = [
+    config = [
       username: "postgres",
       hostname: "localhost",
       database: "eventstore_test",
       password: "postgres",
+      schema: "example",
       pool: EventStore.Config.get_pool()
     ]
 
-    assert Config.parse(original) == [
-             password: "postgres",
-             database: "eventstore_test",
-             hostname: "localhost",
-             username: "postgres",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "example",
+               password: "postgres",
+               database: "eventstore_test",
+               hostname: "localhost",
+               username: "postgres",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "parse socket" do
-    original = [
+    config = [
       username: "postgres",
       socket: "/path/to/socket",
       database: "eventstore_test",
@@ -30,17 +33,19 @@ defmodule EventStore.ConfigTest do
       pool: EventStore.Config.get_pool()
     ]
 
-    assert Config.parse(original) == [
-             password: "postgres",
-             database: "eventstore_test",
-             socket: "/path/to/socket",
-             username: "postgres",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               password: "postgres",
+               database: "eventstore_test",
+               socket: "/path/to/socket",
+               username: "postgres",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "parse socket_dir" do
-    original = [
+    config = [
       username: "postgres",
       socket_dir: "/path/to/socket_dir",
       database: "eventstore_test",
@@ -48,57 +53,61 @@ defmodule EventStore.ConfigTest do
       pool: EventStore.Config.get_pool()
     ]
 
-    assert Config.parse(original) == [
-             password: "postgres",
-             database: "eventstore_test",
-             socket_dir: "/path/to/socket_dir",
-             username: "postgres",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               password: "postgres",
+               database: "eventstore_test",
+               socket_dir: "/path/to/socket_dir",
+               username: "postgres",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "parse url" do
-    original = [url: "postgres://username:password@localhost/database"]
+    config = [url: "postgres://username:password@localhost/database"]
 
-    config = Config.parse(original)
-
-    assert config == [
-             username: "username",
-             password: "password",
-             database: "database",
-             hostname: "localhost",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               username: "username",
+               password: "password",
+               database: "database",
+               hostname: "localhost",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "parse url with query parameters" do
-    original = [url: "postgres://username:password@localhost/database?ssl=true&pool_size=5"]
+    config = [url: "postgres://username:password@localhost/database?ssl=true&pool_size=5"]
 
-    config = Config.parse(original)
-
-    assert config == [
-             username: "username",
-             password: "password",
-             database: "database",
-             hostname: "localhost",
-             pool_size: 5,
-             ssl: true,
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               username: "username",
+               password: "password",
+               database: "database",
+               hostname: "localhost",
+               pool_size: 5,
+               ssl: true,
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "parse database url from environment variable" do
     set_envs(%{"ES_URL" => "postgres://username:password@localhost/database"})
 
-    config = Config.parse(url: {:system, "ES_URL"})
+    config = [url: {:system, "ES_URL"}]
 
-    assert config == [
-             username: "username",
-             password: "password",
-             database: "database",
-             hostname: "localhost",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               username: "username",
+               password: "password",
+               database: "database",
+               hostname: "localhost",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "fetch database settings from environment variables" do
@@ -110,32 +119,35 @@ defmodule EventStore.ConfigTest do
       "ES_PORT" => "5432"
     })
 
-    config =
-      Config.parse(
-        username: {:system, "ES_USERNAME"},
-        password: {:system, "ES_PASSWORD"},
-        database: {:system, "ES_DATABASE"},
-        hostname: {:system, "ES_HOSTNAME"},
-        port: {:system, "ES_PORT"}
-      )
+    config = [
+      username: {:system, "ES_USERNAME"},
+      password: {:system, "ES_PASSWORD"},
+      database: {:system, "ES_DATABASE"},
+      hostname: {:system, "ES_HOSTNAME"},
+      port: {:system, "ES_PORT"}
+    ]
 
-    assert config == [
-             port: 5432,
-             hostname: "hostname",
-             database: "database",
-             password: "password",
-             username: "username",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               port: 5432,
+               hostname: "hostname",
+               database: "database",
+               password: "password",
+               username: "username",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   test "support default value when env variable not set" do
-    config = Config.parse(username: {:system, "ES_USERNAME", "default_username"})
+    config = [username: {:system, "ES_USERNAME", "default_username"}]
 
-    assert config == [
-             username: "default_username",
-             pool: EventStore.Config.get_pool()
-           ]
+    assert Config.parse(config) ==
+             [
+               schema: "public",
+               username: "default_username",
+               pool: EventStore.Config.get_pool()
+             ]
   end
 
   defp set_envs(envs) do

--- a/test/notifications/notify_events_test.exs
+++ b/test/notifications/notify_events_test.exs
@@ -4,29 +4,38 @@ defmodule EventStore.Notifications.NotifyEventsTest do
   alias EventStore.{Config, EventFactory}
   alias TestEventStore, as: EventStore
 
-  @channel "events"
-
   setup do
-    {:ok, conn} = start_listener()
-    {:ok, ref} = Postgrex.Notifications.listen(conn, @channel)
+    {:ok, conn1} = start_listener(TestEventStore.config(), Postgrex.Notifications1)
+    {:ok, conn2} = start_listener(SchemaEventStore.config(), Postgrex.Notifications2)
 
-    [ref: ref]
+    {:ok, ref1} = Postgrex.Notifications.listen(conn1, "public.events")
+    {:ok, ref2} = Postgrex.Notifications.listen(conn2, "example.events")
+
+    [ref1: ref1, ref2: ref2]
   end
 
-  test "should notify events when appended", %{ref: ref} do
+  test "should notify events when appended", %{ref1: ref} do
     stream_uuid = "example-stream"
 
     append_events(stream_uuid, 3)
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "example-stream,1,1,3"}
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "$all,0,1,3"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "example-stream,1,1,3"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "$all,0,1,3"}
 
     append_events(stream_uuid, 2, 3)
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "example-stream,1,4,5"}
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "$all,0,4,5"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "example-stream,1,4,5"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "$all,0,4,5"}
 
     append_events(stream_uuid, 1, 5)
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "example-stream,1,6,6"}
-    assert_receive {:notification, _connection_pid, ^ref, @channel, "$all,0,6,6"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "example-stream,1,6,6"}
+    assert_receive {:notification, _connection_pid, ^ref, "public.events", "$all,0,6,6"}
+  end
+
+  test "should not notify events appended to another schema", %{ref2: ref2} do
+    stream_uuid = "example-stream"
+
+    append_events(stream_uuid, 3)
+
+    refute_receive {:notification, _connection_pid, ^ref2, _channel, _payload}
   end
 
   defp append_events(stream_uuid, count, expected_version \\ 0) do
@@ -35,14 +44,11 @@ defmodule EventStore.Notifications.NotifyEventsTest do
     :ok = EventStore.append_to_stream(stream_uuid, expected_version, events)
   end
 
-  defp start_listener do
-    listener_opts =
-      Config.parsed(TestEventStore, :eventstore)
-      |> Config.sync_connect_postgrex_opts()
-      |> Keyword.put(:name, __MODULE__)
+  defp start_listener(config, id) do
+    listener_opts = Config.sync_connect_postgrex_opts(config)
 
     start_supervised(%{
-      id: Postgrex.Notifications,
+      id: id,
       start: {Postgrex.Notifications, :start_link, [listener_opts]}
     })
   end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,0 +1,7 @@
+defmodule SchemaTest do
+  use EventStore.StorageCase
+
+  alias EventStore.{EventData, EventFactory, RecordedEvent}
+  alias EventStore.Snapshots.SnapshotData
+  alias SchemaEventStore, as: EventStore
+end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,7 +1,117 @@
 defmodule SchemaTest do
   use EventStore.StorageCase
 
-  alias EventStore.{EventData, EventFactory, RecordedEvent}
-  alias EventStore.Snapshots.SnapshotData
-  alias SchemaEventStore, as: EventStore
+  alias EventStore.Config
+  alias EventStore.EventFactory
+  alias EventStore.Storage.Initializer
+
+  setup_all do
+    config = SchemaEventStore.config()
+    postgrex_config = Config.default_postgrex_opts(config)
+
+    {:ok, conn} = Postgrex.start_link(postgrex_config)
+
+    [schema_conn: conn]
+  end
+
+  setup %{schema_conn: conn} do
+    Initializer.reset!(conn)
+
+    start_supervised!(SchemaEventStore)
+
+    :ok
+  end
+
+  describe "event store schema" do
+    setup [:append_events_to_stream]
+
+    test "should append and read events", %{stream_uuid: stream_uuid, events: events} do
+      recorded_events = stream_uuid |> SchemaEventStore.stream_forward() |> Enum.to_list()
+      assert_events(events, recorded_events)
+    end
+
+    test "should not read events from another schema", %{stream_uuid: stream_uuid} do
+      assert TestEventStore.stream_forward(stream_uuid) == {:error, :stream_not_found}
+    end
+
+    test "should subscribe to stream and receive existing events", %{
+      stream_uuid: stream_uuid,
+      events: events
+    } do
+      {:ok, subscription} =
+        SchemaEventStore.subscribe_to_stream(stream_uuid, "test", self(), buffer_size: 3)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+
+      assert_events(events, received_events)
+    end
+
+    test "should subscribe to stream and receive new events", %{stream_uuid: stream_uuid} do
+      {:ok, subscription} =
+        SchemaEventStore.subscribe_to_stream(stream_uuid, "test", self(), start_from: 3)
+
+      assert_receive {:subscribed, ^subscription}
+
+      {:ok, events} = do_append_to_stream(stream_uuid, 1, 3)
+
+      assert_receive {:events, received_events}
+      assert_events(events, received_events)
+    end
+
+    test "should subscribe to stream but not receive existing events from another schema", %{
+      stream_uuid: stream_uuid
+    } do
+      {:ok, subscription} =
+        TestEventStore.subscribe_to_stream(stream_uuid, "test", self(), buffer_size: 3)
+
+      assert_receive {:subscribed, ^subscription}
+      refute_receive {:events, _received_events}
+    end
+
+    test "should subscribe to stream but not receive new events from another schema", %{
+      stream_uuid: stream_uuid
+    } do
+      {:ok, subscription} =
+        TestEventStore.subscribe_to_stream(stream_uuid, "test", self(), start_from: 0)
+
+      assert_receive {:subscribed, ^subscription}
+
+      {:ok, _events} = do_append_to_stream(stream_uuid, 1, 3)
+
+      refute_receive {:events, _received_events}
+    end
+  end
+
+  defp append_events_to_stream(_context) do
+    stream_uuid = UUID.uuid4()
+
+    {:ok, events} = do_append_to_stream(stream_uuid, 3)
+
+    [stream_uuid: stream_uuid, events: events]
+  end
+
+  defp do_append_to_stream(stream_uuid, count, expected_version \\ 0) do
+    events = EventFactory.create_events(count, expected_version + 1)
+
+    :ok = SchemaEventStore.append_to_stream(stream_uuid, expected_version, events)
+
+    {:ok, events}
+  end
+
+  defp assert_events(expected_events, actual_events) do
+    assert length(expected_events) == length(actual_events)
+
+    for {expected, actual} <- Enum.zip(expected_events, actual_events) do
+      assert_event(expected, actual)
+    end
+  end
+
+  defp assert_event(expected_event, actual_event) do
+    assert expected_event.correlation_id == actual_event.correlation_id
+    assert expected_event.causation_id == actual_event.causation_id
+    assert expected_event.event_type == actual_event.event_type
+    assert expected_event.data == actual_event.data
+    assert expected_event.metadata == actual_event.metadata
+  end
 end

--- a/test/storage/database_test.exs
+++ b/test/storage/database_test.exs
@@ -6,8 +6,7 @@ defmodule EventStore.Storage.DatabaseTest do
 
   setup do
     config =
-      TestEventStore
-      |> Config.parsed(:eventstore)
+      TestEventStore.config()
       |> Config.default_postgrex_opts()
       |> Keyword.update!(:database, fn database -> database <> "_temp" end)
 

--- a/test/storage/schema_test.exs
+++ b/test/storage/schema_test.exs
@@ -1,0 +1,29 @@
+defmodule EventStore.Storage.SchemaTest do
+  use ExUnit.Case
+
+  alias EventStore.Storage.Schema
+
+  setup do
+    config =
+      SchemaEventStore.config()
+      |> Keyword.update!(:schema, fn schema -> schema <> "_temp" end)
+
+    on_exit(fn ->
+      Schema.drop(config)
+    end)
+
+    [config: config]
+  end
+
+  test "create schema when already exists", %{config: config} do
+    assert Schema.create(config) == :ok
+    assert Schema.create(config) == {:error, :already_up}
+  end
+
+  test "drop schema when already dropped", %{config: config} do
+    :ok = Schema.create(config)
+
+    assert Schema.drop(config) == :ok
+    assert Schema.drop(config) == {:error, :already_down}
+  end
+end

--- a/test/support/schema_event_store.ex
+++ b/test/support/schema_event_store.ex
@@ -1,0 +1,3 @@
+defmodule SchemaEventStore do
+  use EventStore, otp_app: :eventstore, schema: "example"
+end

--- a/test/support/storage_case.ex
+++ b/test/support/storage_case.ex
@@ -29,7 +29,7 @@ defmodule EventStore.StorageCase do
   setup %{conn: conn} do
     Storage.Initializer.reset!(conn)
 
-    {:ok, _pid} = start_supervised({@event_store, name: @event_store})
+    start_supervised!({@event_store, name: @event_store})
 
     :ok
   end


### PR DESCRIPTION
Allow an event store to specify a Postgres schema. By default the `public` schema will be used.

```elixir
defmodule MyApp.EventStore do
  use EventStore, otp_app: :my_app, schema: "example"
end
```

Or define it in environment config when configuring the database connection settings:

```elixir
# config/config.exs
config :my_app, MyApp.EventStore, schema: "example"
```

This feature allows you to define and start multiple event stores sharing a single Postgres database, but with their data isolated and segregated by schema.

Note the `mix event_store.<task>` tasks to create, initialize, and drop an event store database will also handle creating and/or dropping the schema.