### PR TITLE
Dynamic event store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Support Postgres schemas ([#182](https://github.com/commanded/eventstore/pull/182)).
+- Dynamic event store ([#184](https://github.com/commanded/eventstore/pull/184)).
 
 ### Bug fixes
 

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -73,6 +73,20 @@ defmodule EventStore do
   """
 
   @type t :: module
+  @type option :: {:name, atom} | {:timeout, timeout()}
+  @type options :: [option]
+  @type transient_subscribe_option ::
+          option
+          | {:selector, (EventStore.RecordedEvent.t() -> any())}
+          | {:mapper, (EventStore.RecordedEvent.t() -> any())}
+  @type transient_subscribe_options :: [transient_subscribe_option]
+  @type persistent_subscription_option ::
+          transient_subscribe_option
+          | {:concurrency_limit, pos_integer()}
+          | {:buffer_size, pos_integer()}
+          | {:start_from, :origin | :current | non_neg_integer()}
+          | {:partition_by, (EventStore.RecordedEvent.t() -> any())}
+  @type persistent_subscription_options :: [persistent_subscription_option]
   @type expected_version :: :any_version | :no_stream | :stream_exists | non_neg_integer
   @type start_from :: :origin | :current | non_neg_integer
 
@@ -103,7 +117,7 @@ defmodule EventStore do
       @default_count 1_000
       @default_timeout 15_000
 
-      @conn Module.concat([__MODULE__, EventStore.Postgrex])
+      @default_conn Module.concat([__MODULE__, Postgrex])
 
       def config do
         with {:ok, config} <-
@@ -114,7 +128,7 @@ defmodule EventStore do
 
       def child_spec(opts) do
         %{
-          id: __MODULE__,
+          id: Keyword.get(opts, :name, __MODULE__),
           start: {__MODULE__, :start_link, [opts]},
           type: :supervisor
         }
@@ -122,6 +136,7 @@ defmodule EventStore do
 
       def start_link(opts \\ []) do
         opts = Keyword.merge(unquote(opts), opts)
+
         EventStore.Supervisor.start_link(__MODULE__, @otp_app, @serializer, @registry, opts)
       end
 
@@ -129,106 +144,90 @@ defmodule EventStore do
         Supervisor.stop(pid, :normal, timeout)
       end
 
-      def append_to_stream(stream_uuid, expected_version, events, timeout \\ @default_timeout)
+      def append_to_stream(stream_uuid, expected_version, events, opts \\ [])
 
-      def append_to_stream(@all_stream, _expected_version, _events, _timeout),
+      def append_to_stream(@all_stream, _expected_version, _events, _opts),
         do: {:error, :cannot_append_to_all_stream}
 
-      def append_to_stream(stream_uuid, expected_version, events, timeout) do
-        Stream.append_to_stream(@conn, stream_uuid, expected_version, events, opts(timeout))
+      def append_to_stream(stream_uuid, expected_version, events, opts) do
+        {conn, opts} = opts(opts)
+
+        Stream.append_to_stream(conn, stream_uuid, expected_version, events, opts)
       end
 
       def link_to_stream(
             stream_uuid,
             expected_version,
             events_or_event_ids,
-            timeout \\ @default_timeout
+            opts \\ []
           )
 
-      def link_to_stream(@all_stream, _expected_version, _events_or_event_ids, _timeout),
+      def link_to_stream(@all_stream, _expected_version, _events_or_event_ids, _opts),
         do: {:error, :cannot_append_to_all_stream}
 
-      def link_to_stream(stream_uuid, expected_version, events_or_event_ids, timeout) do
-        Stream.link_to_stream(
-          @conn,
-          stream_uuid,
-          expected_version,
-          events_or_event_ids,
-          opts(timeout)
-        )
+      def link_to_stream(stream_uuid, expected_version, events_or_event_ids, opts) do
+        {conn, opts} = opts(opts)
+
+        Stream.link_to_stream(conn, stream_uuid, expected_version, events_or_event_ids, opts)
       end
 
       def read_stream_forward(
             stream_uuid,
             start_version \\ 0,
             count \\ @default_count,
-            timeout \\ @default_timeout
+            opts \\ []
           )
 
-      def read_stream_forward(stream_uuid, start_version, count, timeout) do
-        Stream.read_stream_forward(@conn, stream_uuid, start_version, count, opts(timeout))
+      def read_stream_forward(stream_uuid, start_version, count, opts) do
+        {conn, opts} = opts(opts)
+
+        Stream.read_stream_forward(conn, stream_uuid, start_version, count, opts)
       end
 
       def read_all_streams_forward(
             start_event_number \\ 0,
             count \\ @default_count,
-            timeout \\ @default_timeout
+            opts \\ []
           )
 
-      def read_all_streams_forward(start_event_number, count, timeout) do
-        Stream.read_stream_forward(
-          @conn,
-          @all_stream,
-          start_event_number,
-          count,
-          opts(timeout)
-        )
+      def read_all_streams_forward(start_event_number, count, opts) do
+        {conn, opts} = opts(opts)
+
+        Stream.read_stream_forward(conn, @all_stream, start_event_number, count, opts)
       end
 
-      def stream_forward(
-            stream_uuid,
-            start_version \\ 0,
-            read_batch_size \\ @default_batch_size,
-            timeout \\ @default_timeout
-          )
+      def stream_forward(stream_uuid, start_version \\ 0, opts \\ [])
 
-      def stream_forward(stream_uuid, start_version, read_batch_size, timeout) do
-        Stream.stream_forward(
-          @conn,
-          stream_uuid,
-          start_version,
-          read_batch_size,
-          opts(timeout)
-        )
+      def stream_forward(stream_uuid, start_version, opts) do
+        {conn, opts} = opts(opts)
+
+        opts = Keyword.put_new(opts, :read_batch_size, @default_batch_size)
+
+        Stream.stream_forward(conn, stream_uuid, start_version, opts)
       end
 
-      def stream_all_forward(
-            start_event_number \\ 0,
-            read_batch_size \\ @default_batch_size,
-            timeout \\ @default_timeout
-          )
+      def stream_all_forward(start_version \\ 0, opts \\ [])
 
-      def stream_all_forward(start_event_number, read_batch_size, timeout) do
-        Stream.stream_forward(
-          @conn,
-          @all_stream,
-          start_event_number,
-          read_batch_size,
-          opts(timeout)
-        )
-      end
+      def stream_all_forward(start_version, opts),
+        do: stream_forward(@all_stream, start_version, opts)
 
       def subscribe(stream_uuid, opts \\ []) do
-        Registration.subscribe(__MODULE__, @registry, stream_uuid, opts)
+        name = Keyword.get(opts, :name, __MODULE__)
+
+        Registration.subscribe(name, @registry, stream_uuid, opts)
       end
 
       def subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts \\ []) do
+        {conn, _opts} = opts(opts)
+
         with {start_from, opts} <- Keyword.pop(opts, :start_from, :origin),
-             {:ok, start_from} <- Stream.start_from(@conn, stream_uuid, start_from) do
+             {:ok, start_from} <- Stream.start_from(conn, stream_uuid, start_from) do
+          name = Keyword.get(opts, :name, __MODULE__)
+
           opts =
             Keyword.merge(opts,
-              conn: @conn,
-              event_store: __MODULE__,
+              conn: conn,
+              event_store: name,
               registry: @registry,
               serializer: @serializer,
               retry_interval: @subscription_retry_interval,
@@ -249,36 +248,77 @@ defmodule EventStore do
         Subscription.ack(subscription, ack)
       end
 
-      def unsubscribe_from_stream(stream_uuid, subscription_name) do
-        Subscriptions.unsubscribe_from_stream(__MODULE__, stream_uuid, subscription_name)
+      def unsubscribe_from_stream(stream_uuid, subscription_name, opts \\ []) do
+        name = Keyword.get(opts, :name, __MODULE__)
+
+        Subscriptions.unsubscribe_from_stream(name, stream_uuid, subscription_name)
       end
 
-      def unsubscribe_from_all_streams(subscription_name) do
-        Subscriptions.unsubscribe_from_stream(__MODULE__, @all_stream, subscription_name)
+      def unsubscribe_from_all_streams(subscription_name, opts \\ []) do
+        name = Keyword.get(opts, :name, __MODULE__)
+
+        Subscriptions.unsubscribe_from_stream(name, @all_stream, subscription_name)
       end
 
-      def delete_subscription(stream_uuid, subscription_name) do
+      def delete_subscription(stream_uuid, subscription_name, opts \\ []) do
+        name = Keyword.get(opts, :name, __MODULE__)
+
         Subscriptions.delete_subscription(__MODULE__, stream_uuid, subscription_name)
       end
 
-      def delete_all_streams_subscription(subscription_name) do
+      def delete_all_streams_subscription(subscription_name, opts \\ []) do
+        name = Keyword.get(opts, :name, __MODULE__)
+
         Subscriptions.delete_subscription(__MODULE__, @all_stream, subscription_name)
       end
 
-      def read_snapshot(source_uuid) do
-        Snapshotter.read_snapshot(@conn, source_uuid, @serializer)
+      def read_snapshot(source_uuid, opts \\ []) do
+        {conn, opts} = opts(opts)
+
+        Snapshotter.read_snapshot(conn, source_uuid, @serializer, opts)
       end
 
-      def record_snapshot(%SnapshotData{} = snapshot) do
-        Snapshotter.record_snapshot(@conn, snapshot, @serializer)
+      def record_snapshot(%SnapshotData{} = snapshot, opts \\ []) do
+        {conn, opts} = opts(opts)
+
+        Snapshotter.record_snapshot(conn, snapshot, @serializer, opts)
       end
 
-      def delete_snapshot(source_uuid) do
-        Snapshotter.delete_snapshot(@conn, source_uuid)
+      def delete_snapshot(source_uuid, opts \\ []) do
+        {conn, opts} = opts(opts)
+
+        Snapshotter.delete_snapshot(conn, source_uuid, opts)
       end
 
-      defp opts(timeout) when is_integer(timeout) or timeout == :infinity do
-        [timeout: timeout, serializer: @serializer]
+      defp opts(opts) do
+        conn =
+          case Keyword.get(opts, :name) do
+            nil -> @default_conn
+            name -> Module.concat([name, Postgrex])
+          end
+
+        timeout = timeout(opts)
+
+        {conn, [timeout: timeout, serializer: @serializer]}
+      end
+
+      defp timeout(opts) do
+        case Keyword.get(opts, :timeout) do
+          nil ->
+            @default_timeout
+
+          timeout when is_integer(timeout) ->
+            timeout
+
+          :infinity ->
+            :infinity
+
+          invalid ->
+            raise ArgumentError,
+              message:
+                "Invalid timeout provided, expected an integer or :infinity but got: " <>
+                  inspect(invalid)
+        end
       end
     end
   end
@@ -316,7 +356,7 @@ defmodule EventStore do
   @doc """
   Shuts down the event store.
   """
-  @callback stop(timeout) :: :ok
+  @callback stop(pid, timeout) :: :ok
 
   @doc """
   Append one or more events to a stream atomically.
@@ -338,8 +378,10 @@ defmodule EventStore do
 
     - `events` is a list of `%EventStore.EventData{}` structs.
 
-    - `timeout` an optional timeout for the database transaction, in
-      milliseconds. Defaults to 15_000ms.
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
 
   Returns `:ok` on success, or an `{:error, reason}` tagged tuple. The returned
   error may be due to one of the following reasons:
@@ -350,13 +392,12 @@ defmodule EventStore do
       was `:no_stream`.
     - `{:error, :stream_does_not_exist}` when the stream does not exist, but
       expected version was `:stream_exists`.
-
   """
   @callback append_to_stream(
               stream_uuid :: String.t(),
               expected_version,
               events :: list(EventData.t()),
-              timeout :: timeout() | nil
+              opts :: options
             ) ::
               :ok
               | {:error, :cannot_append_to_all_stream}
@@ -390,8 +431,10 @@ defmodule EventStore do
     - `events_or_event_ids` is a list of `%EventStore.EventData{}` structs or
       event ids.
 
-    - `timeout` an optional timeout for the database transaction, in
-      milliseconds. Defaults to 15_000ms.
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
 
   Returns `:ok` on success, or an `{:error, reason}` tagged tuple. The returned
   error may be due to one of the following reasons:
@@ -402,13 +445,12 @@ defmodule EventStore do
       was `:no_stream`.
     - `{:error, :stream_does_not_exist}` when the stream does not exist, but
       expected version was `:stream_exists`.
-
   """
   @callback link_to_stream(
               stream_uuid :: String.t(),
               expected_version,
               events :: list(EventStore.RecordedEvent.t()) | list(non_neg_integer),
-              timeout :: timeout() | nil
+              opts :: options
             ) ::
               :ok
               | {:error, :cannot_append_to_all_stream}
@@ -429,18 +471,17 @@ defmodule EventStore do
     - `count` optionally, the maximum number of events to read.
       If not set it will be limited to returning 1,000 events from the stream.
 
-    - `timeout` an optional timeout for querying the database, in milliseconds.
-      Defaults to 15_000ms.
-
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
   """
   @callback read_stream_forward(
               stream_uuid :: String.t(),
               start_version :: non_neg_integer,
               count :: non_neg_integer,
-              timeout :: timeout() | nil
-            ) ::
-              {:ok, list(EventStore.RecordedEvent.t())}
-              | {:error, reason :: term}
+              opts :: options
+            ) :: {:ok, list(EventStore.RecordedEvent.t())} | {:error, reason :: term}
 
   @doc """
   Reads the requested number of events from all streams, in the order in which
@@ -452,16 +493,16 @@ defmodule EventStore do
     - `count` optionally, the maximum number of events to read.
       If not set it will be limited to returning 1,000 events from all streams.
 
-    - `timeout` an optional timeout for querying the database, in milliseconds.
-      Defaults to 15_000ms.
-
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
   """
   @callback read_all_streams_forward(
               start_event_number :: non_neg_integer,
               count :: non_neg_integer,
-              timeout :: timeout() | nil
-            ) ::
-              {:ok, list(EventStore.RecordedEvent.t())} | {:error, reason :: term}
+              opts :: options
+            ) :: {:ok, list(EventStore.RecordedEvent.t())} | {:error, reason :: term}
 
   @doc """
   Streams events from the given stream, in the order in which they were
@@ -470,20 +511,18 @@ defmodule EventStore do
     - `start_version` optionally, the version number of the first event to read.
       Defaults to the beginning of the stream if not set.
 
-    - `read_batch_size` optionally, the number of events to read at a time from storage.
-      Defaults to reading 1,000 events per batch.
-
-    - `timeout` an optional timeout for querying the database (per batch), in
-      milliseconds. Defaults to 15_000ms.
-
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
+      - `read_batch_size` optionally, the number of events to read at a time
+        from storage. Defaults to reading 1,000 events per batch.
   """
   @callback stream_forward(
               stream_uuid :: String.t(),
               start_version :: non_neg_integer,
-              read_batch_size :: non_neg_integer,
-              timeout :: timeout() | nil
-            ) ::
-              Enumerable.t() | {:error, reason :: term}
+              opts :: [options | {:read_batch_size, non_neg_integer}]
+            ) :: Enumerable.t() | {:error, reason :: term}
 
   @doc """
   Streams events from all streams, in the order in which they were originally
@@ -492,16 +531,16 @@ defmodule EventStore do
     - `start_event_number` optionally, the number of the first event to read.
       Defaults to the beginning of the stream if not set.
 
-    - `read_batch_size` optionally, the number of events to read at a time from
-      storage. Defaults to reading 1,000 events per batch.
-
-    - `timeout` an optional timeout for querying the database (per batch), in
-      milliseconds. Defaults to 15_000ms.
+    - `opts` an optional keyword list containing:
+      - `name` the name of the event store if provided to `start_link/1`.
+      - `timeout` an optional timeout for the database transaction, in
+        milliseconds. Defaults to 15_000ms.
+      - `read_batch_size` optionally, the number of events to read at a time from
+        storage. Defaults to reading 1,000 events per batch.
   """
   @callback stream_all_forward(
               start_event_number :: non_neg_integer,
-              read_batch_size :: non_neg_integer,
-              timeout :: timeout() | nil
+              opts :: [options | {:read_batch_size, non_neg_integer}]
             ) :: Enumerable.t()
 
   @doc """
@@ -511,6 +550,7 @@ defmodule EventStore do
       Use the `$all` identifier to subscribe to events from all streams.
 
     - `opts` is an optional map providing additional subscription configuration:
+      - `name` the name of the event store if provided to `start_link/1`.
       - `selector` to define a function to filter each event, i.e. returns
         only those elements for which fun returns a truthy value
       - `mapper` to define a function to map each recorded event before sending
@@ -541,11 +581,8 @@ defmodule EventStore do
       end
 
   """
-  @callback subscribe(
-              stream_uuid :: String.t(),
-              selector: (EventStore.RecordedEvent.t() -> any()),
-              mapper: (EventStore.RecordedEvent.t() -> any())
-            ) :: :ok | {:error, term}
+  @callback subscribe(stream_uuid :: String.t(), opts :: transient_subscribe_options) ::
+              :ok | {:error, term}
 
   @doc """
   Create a persistent subscription to a single stream.
@@ -562,6 +599,8 @@ defmodule EventStore do
       notification messages.
 
     - `opts` is an optional map providing additional subscription configuration:
+
+      - `name` the name of the event store if provided to `start_link/1`.
 
       - `start_from` is a pointer to the first event to receive.
         It must be one of:
@@ -643,7 +682,7 @@ defmodule EventStore do
               stream_uuid :: String.t(),
               subscription_name :: String.t(),
               subscriber :: pid,
-              opts :: keyword
+              opts :: persistent_subscription_options
             ) ::
               {:ok, subscription :: pid}
               | {:error, :already_subscribed}
@@ -663,6 +702,8 @@ defmodule EventStore do
       notification messages.
 
     - `opts` is an optional map providing additional subscription configuration:
+
+      - `name` the name of the event store if provided to `start_link/1`.
 
       - `start_from` is a pointer to the first event to receive.
         It must be one of:
@@ -710,7 +751,7 @@ defmodule EventStore do
   @callback subscribe_to_all_streams(
               subscription_name :: String.t(),
               subscriber :: pid,
-              opts :: keyword
+              opts :: persistent_subscription_options
             ) ::
               {:ok, subscription :: pid}
               | {:error, :already_subscribed}
@@ -742,7 +783,11 @@ defmodule EventStore do
 
   Returns `:ok` on success.
   """
-  @callback unsubscribe_from_stream(stream_uuid :: String.t(), subscription_name :: String.t()) ::
+  @callback unsubscribe_from_stream(
+              stream_uuid :: String.t(),
+              subscription_name :: String.t(),
+              opts :: options
+            ) ::
               :ok
 
   @doc """
@@ -753,7 +798,7 @@ defmodule EventStore do
 
   Returns `:ok` on success.
   """
-  @callback unsubscribe_from_all_streams(subscription_name :: String.t()) :: :ok
+  @callback unsubscribe_from_all_streams(subscription_name :: String.t(), opts :: options) :: :ok
 
   @doc """
   Delete an existing persistent subscription.
@@ -765,7 +810,11 @@ defmodule EventStore do
 
   Returns `:ok` on success.
   """
-  @callback delete_subscription(stream_uuid :: String.t(), subscription_name :: String.t()) ::
+  @callback delete_subscription(
+              stream_uuid :: String.t(),
+              subscription_name :: String.t(),
+              opts :: options
+            ) ::
               :ok | {:error, term}
 
   @doc """
@@ -776,7 +825,7 @@ defmodule EventStore do
 
   Returns `:ok` on success.
   """
-  @callback delete_all_streams_subscription(subscription_name :: String.t()) ::
+  @callback delete_all_streams_subscription(subscription_name :: String.t(), opts :: options) ::
               :ok | {:error, term}
 
   @doc """
@@ -785,7 +834,7 @@ defmodule EventStore do
   Returns `{:ok, %EventStore.Snapshots.SnapshotData{}}` on success, or
   `{:error, :snapshot_not_found}` when unavailable.
   """
-  @callback read_snapshot(source_uuid :: String.t()) ::
+  @callback read_snapshot(source_uuid :: String.t(), opts :: options) ::
               {:ok, SnapshotData.t()} | {:error, :snapshot_not_found}
 
   @doc """
@@ -793,12 +842,14 @@ defmodule EventStore do
 
   Returns `:ok` on success.
   """
-  @callback record_snapshot(snapshot :: SnapshotData.t()) :: :ok | {:error, reason :: term}
+  @callback record_snapshot(snapshot :: SnapshotData.t(), opts :: options) ::
+              :ok | {:error, reason :: term}
 
   @doc """
   Delete a previously recorded snapshop for a given source.
 
   Returns `:ok` on success, or when the snapshot does not exist.
   """
-  @callback delete_snapshot(source_uuid :: String.t()) :: :ok | {:error, reason :: term}
+  @callback delete_snapshot(source_uuid :: String.t(), opts :: options) ::
+              :ok | {:error, reason :: term}
 end

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -264,13 +264,13 @@ defmodule EventStore do
       def delete_subscription(stream_uuid, subscription_name, opts \\ []) do
         name = name(opts)
 
-        Subscriptions.delete_subscription(__MODULE__, stream_uuid, subscription_name)
+        Subscriptions.delete_subscription(name, stream_uuid, subscription_name)
       end
 
       def delete_all_streams_subscription(subscription_name, opts \\ []) do
         name = name(opts)
 
-        Subscriptions.delete_subscription(__MODULE__, @all_stream, subscription_name)
+        Subscriptions.delete_subscription(name, @all_stream, subscription_name)
       end
 
       def read_snapshot(source_uuid, opts \\ []) do
@@ -293,8 +293,9 @@ defmodule EventStore do
 
       defp opts(opts) do
         name = name(opts)
-        timeout = timeout(opts)
         conn = Module.concat([name, Postgrex])
+
+        timeout = timeout(opts)
 
         {conn, [timeout: timeout, serializer: @serializer]}
       end

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -157,9 +157,7 @@ defmodule EventStore.Config do
     |> Keyword.put(:after_connect, set_schema_search_path(config))
   end
 
-  def postgrex_opts(config) do
-    event_store = Keyword.fetch!(config, :event_store)
-
+  def postgrex_opts(config, name) do
     [
       pool_size: 10,
       pool_overflow: 0,
@@ -178,7 +176,7 @@ defmodule EventStore.Config do
         ]
     )
     |> Keyword.put(:backoff_type, :exp)
-    |> Keyword.put(:name, Module.concat([event_store, EventStore.Postgrex]))
+    |> Keyword.put(:name, Module.concat([name, Postgrex]))
     |> Keyword.put(:after_connect, set_schema_search_path(config))
   end
 

--- a/lib/event_store/snapshots/snapshot_data.ex
+++ b/lib/event_store/snapshots/snapshot_data.ex
@@ -1,37 +1,38 @@
 defmodule EventStore.Snapshots.SnapshotData do
   @moduledoc """
-  Snapshot data
+  Snapshot data.
   """
 
   alias EventStore.Snapshots.SnapshotData
 
-  defstruct source_uuid: nil,
-            source_version: nil,
-            source_type: nil,
-            data: nil,
-            metadata: nil,
-            created_at: nil
+  defstruct [:source_uuid, :source_version, :source_type, :data, :metadata, :created_at]
 
   @type t :: %SnapshotData{
-    source_uuid: String.t,
-    source_version: non_neg_integer,
-    source_type: String.t,
-    data: binary,
-    metadata: binary,
-    created_at: DateTime.t
-  }
+          source_uuid: String.t(),
+          source_version: non_neg_integer,
+          source_type: String.t(),
+          data: binary,
+          metadata: binary,
+          created_at: DateTime.t()
+        }
 
-  def serialize(%SnapshotData{data: data, metadata: metadata} = snapshot, serializer) do
-    %SnapshotData{snapshot |
-      data: serializer.serialize(data),
-      metadata: serializer.serialize(metadata)
+  def serialize(%SnapshotData{} = snapshot, serializer) do
+    %SnapshotData{data: data, metadata: metadata} = snapshot
+
+    %SnapshotData{
+      snapshot
+      | data: serializer.serialize(data),
+        metadata: serializer.serialize(metadata)
     }
   end
 
-  def deserialize(%SnapshotData{source_type: source_type, data: data, metadata: metadata} = snapshot, serializer) do
-    %SnapshotData{snapshot |
-      data: serializer.deserialize(data, type: source_type),
-      metadata: serializer.deserialize(metadata, [])
+  def deserialize(%SnapshotData{} = snapshot, serializer) do
+    %SnapshotData{source_type: source_type, data: data, metadata: metadata} = snapshot
+
+    %SnapshotData{
+      snapshot
+      | data: serializer.deserialize(data, type: source_type),
+        metadata: serializer.deserialize(metadata, [])
     }
   end
 end

--- a/lib/event_store/snapshots/snapshotter.ex
+++ b/lib/event_store/snapshots/snapshotter.ex
@@ -8,12 +8,10 @@ defmodule EventStore.Snapshots.Snapshotter do
   Read a snapshot, if available, for a given source.
   """
   def read_snapshot(conn, source_uuid, serializer, opts \\ []) do
-    case Snapshot.read_snapshot(conn, source_uuid, opts) do
-      {:ok, snapshot} ->
-        {:ok, SnapshotData.deserialize(snapshot, serializer)}
+    with {:ok, snapshot} <- Snapshot.read_snapshot(conn, source_uuid, opts) do
+      deserialized = SnapshotData.deserialize(snapshot, serializer)
 
-      reply ->
-        reply
+      {:ok, deserialized}
     end
   end
 
@@ -23,9 +21,9 @@ defmodule EventStore.Snapshots.Snapshotter do
   Returns `:ok` on success.
   """
   def record_snapshot(conn, %SnapshotData{} = snapshot, serializer, opts \\ []) do
-    snapshot_data = SnapshotData.serialize(snapshot, serializer)
+    serialized = SnapshotData.serialize(snapshot, serializer)
 
-    Snapshot.record_snapshot(conn, snapshot_data, opts)
+    Snapshot.record_snapshot(conn, serialized, opts)
   end
 
   @doc """
@@ -33,6 +31,7 @@ defmodule EventStore.Snapshots.Snapshotter do
 
   Returns `:ok` on success.
   """
-  def delete_snapshot(conn, source_uuid, opts \\ []),
-    do: Snapshot.delete_snapshot(conn, source_uuid, opts)
+  def delete_snapshot(conn, source_uuid, opts \\ []) do
+    Snapshot.delete_snapshot(conn, source_uuid, opts)
+  end
 end

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -13,8 +13,6 @@ defmodule EventStore.Streams.Stream do
     with {:ok, stream} <- stream_info(conn, stream_uuid, opts),
          {:ok, stream} <- prepare_stream(conn, expected_version, stream, opts) do
       do_append_to_storage(conn, events, stream, serializer, opts)
-    else
-      reply -> reply
     end
   end
 
@@ -24,24 +22,18 @@ defmodule EventStore.Streams.Stream do
     with {:ok, stream} <- stream_info(conn, stream_uuid, opts),
          {:ok, stream} <- prepare_stream(conn, expected_version, stream, opts) do
       do_link_to_storage(conn, events_or_event_ids, stream, opts)
-    else
-      reply -> reply
     end
   end
 
   def read_stream_forward(conn, stream_uuid, start_version, count, opts \\ []) do
-    {serializer, opts} = Keyword.pop(opts, :serializer)
-
-    with {:ok, stream} <- stream_info(conn, stream_uuid, opts) do
-      read_storage_forward(conn, start_version, count, stream, serializer, opts)
+    with {:ok, stream_id} <- stream_id(conn, stream_uuid, opts) do
+      read_storage_forward(conn, stream_id, start_version, count, opts)
     end
   end
 
-  def stream_forward(conn, stream_uuid, start_version, read_batch_size, opts \\ []) do
-    {serializer, opts} = Keyword.pop(opts, :serializer)
-
-    with {:ok, stream} <- stream_info(conn, stream_uuid, opts) do
-      stream_storage_forward(conn, start_version, read_batch_size, stream, serializer, opts)
+  def stream_forward(conn, stream_uuid, start_version, opts \\ []) do
+    with {:ok, stream_id} <- stream_id(conn, stream_uuid, opts) do
+      stream_storage_forward(conn, stream_id, start_version, opts)
     end
   end
 
@@ -59,13 +51,25 @@ defmodule EventStore.Streams.Stream do
   def start_from(_conn, _stream_uuid, _start_from, _opts),
     do: {:error, :invalid_start_from}
 
+  def stream_id(conn, stream_uuid, opts \\ []) do
+    opts = Keyword.take(opts, [:timeout])
+
+    with {:ok, stream_id, _stream_version} <- Storage.stream_info(conn, stream_uuid, opts) do
+      {:ok, stream_id}
+    end
+  end
+
   def stream_version(conn, stream_uuid, opts \\ []) do
+    opts = Keyword.take(opts, [:timeout])
+
     with {:ok, _stream_id, stream_version} <- Storage.stream_info(conn, stream_uuid, opts) do
       {:ok, stream_version}
     end
   end
 
   defp stream_info(conn, stream_uuid, opts) do
+    opts = Keyword.take(opts, [:timeout])
+
     with {:ok, stream_id, stream_version} <- Storage.stream_info(conn, stream_uuid, opts) do
       stream = %Stream{
         stream_uuid: stream_uuid,
@@ -213,17 +217,16 @@ defmodule EventStore.Streams.Stream do
 
   defp read_storage_forward(
          _conn,
+         stream_id,
          _start_version,
          _count,
-         %Stream{stream_id: stream_id},
-         _serializer,
          _opts
        )
        when is_nil(stream_id),
        do: {:error, :stream_not_found}
 
-  defp read_storage_forward(conn, start_version, count, %Stream{} = stream, serializer, opts) do
-    %Stream{stream_id: stream_id} = stream
+  defp read_storage_forward(conn, stream_id, start_version, count, opts) do
+    {serializer, opts} = Keyword.pop(opts, :serializer)
 
     case Storage.read_stream_forward(conn, stream_id, start_version, count, opts) do
       {:ok, recorded_events} ->
@@ -236,32 +239,20 @@ defmodule EventStore.Streams.Stream do
     end
   end
 
-  defp stream_storage_forward(
-         _conn,
-         _start_version,
-         _read_batch_size,
-         %Stream{stream_id: stream_id},
-         _serializer,
-         _opts
-       )
+  defp stream_storage_forward(_conn, stream_id, _start_version, _opts)
        when is_nil(stream_id),
        do: {:error, :stream_not_found}
 
-  defp stream_storage_forward(conn, 0, read_batch_size, stream, serializer, opts),
-    do: stream_storage_forward(conn, 1, read_batch_size, stream, serializer, opts)
+  defp stream_storage_forward(conn, stream_id, 0, opts),
+    do: stream_storage_forward(conn, stream_id, 1, opts)
 
-  defp stream_storage_forward(
-         conn,
-         start_version,
-         read_batch_size,
-         %Stream{} = stream,
-         serializer,
-         opts
-       ) do
+  defp stream_storage_forward(conn, stream_id, start_version, opts) do
+    read_batch_size = Keyword.fetch!(opts, :read_batch_size)
+
     Elixir.Stream.resource(
       fn -> start_version end,
       fn next_version ->
-        case read_storage_forward(conn, next_version, read_batch_size, stream, serializer, opts) do
+        case read_storage_forward(conn, stream_id, next_version, read_batch_size, opts) do
           {:ok, []} -> {:halt, next_version}
           {:ok, events} -> {events, next_version + length(events)}
         end

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -28,7 +28,7 @@ defmodule EventStore.Subscriptions do
     :ok =
       Subscriptions.Supervisor.shutdown_subscription(event_store, stream_uuid, subscription_name)
 
-    conn = Module.concat(event_store, EventStore.Postgrex)
+    conn = Module.concat(event_store, Postgrex)
 
     Storage.delete_subscription(conn, stream_uuid, subscription_name, opts)
   end

--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -16,12 +16,12 @@ defmodule EventStore.Supervisor do
   Starts the event store supervisor.
   """
   def start_link(event_store, otp_app, serializer, registry, opts) do
-    sup_opts = if name = Keyword.get(opts, :name, event_store), do: [name: name], else: []
+    name = Keyword.get(opts, :name, event_store)
 
     Supervisor.start_link(
       __MODULE__,
-      {event_store, otp_app, serializer, registry, opts},
-      sup_opts
+      {event_store, otp_app, serializer, registry, opts, name},
+      name: name
     )
   end
 
@@ -42,7 +42,7 @@ defmodule EventStore.Supervisor do
     config =
       Application.get_env(otp_app, event_store, [])
       |> Keyword.merge(opts)
-      |> Keyword.merge(otp_app: otp_app, event_store: event_store)
+      |> Keyword.put(:otp_app, otp_app)
 
     case event_store_init(event_store, config) do
       {:ok, config} ->
@@ -58,17 +58,17 @@ defmodule EventStore.Supervisor do
   ## Supervisor callbacks
 
   @doc false
-  def init({event_store, otp_app, serializer, registry, opts}) do
+  def init({event_store, otp_app, serializer, registry, opts, name}) do
     case runtime_config(event_store, otp_app, opts) do
       {:ok, config} ->
-        advisory_locks_name = Module.concat([event_store, AdvisoryLocks])
+        advisory_locks_name = Module.concat([name, AdvisoryLocks])
         advisory_locks_postgrex_name = Module.concat([advisory_locks_name, Postgrex])
-        subscriptions_name = Module.concat([event_store, Subscriptions.Supervisor])
-        subscriptions_registry_name = Module.concat([event_store, Subscriptions.Registry])
+        subscriptions_name = Module.concat([name, Subscriptions.Supervisor])
+        subscriptions_registry_name = Module.concat([name, Subscriptions.Registry])
 
         children =
           [
-            {Postgrex, Config.postgrex_opts(config)},
+            {Postgrex, Config.postgrex_opts(config, name)},
             MonitoredServer.child_spec(
               mfa: {Postgrex, :start_link, [Config.sync_connect_postgrex_opts(config)]},
               name: advisory_locks_postgrex_name
@@ -79,8 +79,8 @@ defmodule EventStore.Supervisor do
               {Registry, keys: :unique, name: subscriptions_registry_name},
               id: subscriptions_registry_name
             ),
-            {Notifications.Supervisor, {event_store, registry, serializer, config}}
-          ] ++ Registration.child_spec(event_store, registry)
+            {Notifications.Supervisor, {name, registry, serializer, config}}
+          ] ++ Registration.child_spec(name, registry)
 
         Supervisor.init(children, strategy: :one_for_all)
 

--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -15,12 +15,10 @@ defmodule EventStore.Supervisor do
   @doc """
   Starts the event store supervisor.
   """
-  def start_link(event_store, otp_app, serializer, registry, opts) do
-    name = Keyword.get(opts, :name, event_store)
-
+  def start_link(event_store, otp_app, serializer, registry, name, opts) do
     Supervisor.start_link(
       __MODULE__,
-      {event_store, otp_app, serializer, registry, opts, name},
+      {event_store, otp_app, serializer, registry, name, opts},
       name: name
     )
   end
@@ -58,7 +56,7 @@ defmodule EventStore.Supervisor do
   ## Supervisor callbacks
 
   @doc false
-  def init({event_store, otp_app, serializer, registry, opts, name}) do
+  def init({event_store, otp_app, serializer, registry, name, opts}) do
     case runtime_config(event_store, otp_app, opts) do
       {:ok, config} ->
         advisory_locks_name = Module.concat([name, AdvisoryLocks])

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "db_connection": {:hex, :db_connection, "2.1.1", "a51e8a2ee54ef2ae6ec41a668c85787ed40cb8944928c191280fe34c15b76ae5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.2.0", "e923e88887cd60f9891fd324ac5e0290954511d090553c415fbf54be4c57ee63", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
@@ -14,7 +14,7 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.15.2", "052dad08d934863d1a4dcbd48ae7fc2af21a8535f556121e91b13b2884b0965a", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.15.3", "5806baa8a19a68c4d07c7a624ccdb9b57e89cbc573f1b98099e3741214746ae4", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "db_connection": {:hex, :db_connection, "2.1.1", "a51e8a2ee54ef2ae6ec41a668c85787ed40cb8944928c191280fe34c15b76ae5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
@@ -16,5 +16,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
-  "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.15.2", "052dad08d934863d1a4dcbd48ae7fc2af21a8535f556121e91b13b2884b0965a", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
 }

--- a/test/append_to_stream_test.exs
+++ b/test/append_to_stream_test.exs
@@ -81,10 +81,10 @@ defmodule EventStore.AppendToStreamTest do
     stream_uuid = UUID.uuid4()
     events = EventFactory.create_events(8_001)
 
-    assert :ok = EventStore.append_to_stream(stream_uuid, 0, events, :infinity)
+    assert :ok = EventStore.append_to_stream(stream_uuid, 0, events, timeout: :infinity)
 
-    assert 1..8_001 |> Enum.to_list() ==
-             EventStore.stream_all_forward() |> Stream.map(& &1.event_number) |> Enum.to_list()
+    assert EventStore.stream_all_forward() |> Stream.map(& &1.event_number) |> Enum.to_list() ==
+             Enum.to_list(1..8_001)
   end
 
   defp append_events_to_stream(_context) do

--- a/test/dynamic_event_store_test.exs
+++ b/test/dynamic_event_store_test.exs
@@ -1,0 +1,59 @@
+defmodule DynamicEventStoreTest do
+  use EventStore.StorageCase
+
+  alias EventStore.EventFactory
+  alias TestEventStore, as: EventStore
+
+  describe "dynamic event store" do
+    setup do
+      start_supervised!({EventStore, name: :eventstore1, schema: "public"})
+      start_supervised!({EventStore, name: :eventstore2, schema: "public"})
+      start_supervised!({EventStore, name: :schema_eventstore, schema: "example"})
+      :ok
+    end
+
+    test "should append and read events" do
+      stream_uuid = UUID.uuid4()
+
+      {:ok, events} = append_events_to_stream(:eventstore1, stream_uuid, 3)
+
+      assert_recorded_events(:eventstore1, stream_uuid, events)
+      assert_recorded_events(:eventstore2, stream_uuid, events)
+
+      assert EventStore.stream_forward(stream_uuid, 0, name: :schema_eventstore) ==
+               {:error, :stream_not_found}
+    end
+  end
+
+  defp append_events_to_stream(event_store_name, stream_uuid, count, expected_version \\ 0) do
+    events = EventFactory.create_events(count, expected_version + 1)
+
+    :ok =
+      EventStore.append_to_stream(stream_uuid, expected_version, events, name: event_store_name)
+
+    {:ok, events}
+  end
+
+  defp assert_recorded_events(event_store_name, stream_uuid, expected_events) do
+    actual_events =
+      EventStore.stream_forward(stream_uuid, 0, name: event_store_name) |> Enum.to_list()
+
+    assert_events(expected_events, actual_events)
+  end
+
+  defp assert_events(expected_events, actual_events) do
+    assert length(expected_events) == length(actual_events)
+
+    for {expected, actual} <- Enum.zip(expected_events, actual_events) do
+      assert_event(expected, actual)
+    end
+  end
+
+  defp assert_event(expected_event, actual_event) do
+    assert expected_event.correlation_id == actual_event.correlation_id
+    assert expected_event.causation_id == actual_event.causation_id
+    assert expected_event.event_type == actual_event.event_type
+    assert expected_event.data == actual_event.data
+    assert expected_event.metadata == actual_event.metadata
+  end
+end

--- a/test/streams/all_stream_test.exs
+++ b/test/streams/all_stream_test.exs
@@ -28,7 +28,8 @@ defmodule EventStore.Streams.AllStreamTest do
       serializer: serializer
     } do
       read_events =
-        Stream.stream_forward(conn, @all_stream, 0, 1, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, @all_stream, 0, read_batch_size: 1, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 6
     end
@@ -38,7 +39,8 @@ defmodule EventStore.Streams.AllStreamTest do
       serializer: serializer
     } do
       read_events =
-        Stream.stream_forward(conn, @all_stream, 0, 2, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, @all_stream, 0, read_batch_size: 2, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 6
     end
@@ -48,7 +50,7 @@ defmodule EventStore.Streams.AllStreamTest do
       serializer: serializer
     } do
       read_events =
-        Stream.stream_forward(conn, @all_stream, 0, 1_000, serializer: serializer)
+        Stream.stream_forward(conn, @all_stream, 0, read_batch_size: 1_000, serializer: serializer)
         |> Enum.to_list()
 
       assert length(read_events) == 6

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -177,7 +177,10 @@ defmodule EventStore.Streams.SingleStreamTest do
     unknown_stream_uuid = UUID.uuid4()
 
     assert {:error, :stream_not_found} =
-             Stream.stream_forward(conn, unknown_stream_uuid, 0, 1, serializer: serializer)
+             Stream.stream_forward(conn, unknown_stream_uuid, 0,
+               read_batch_size: 1,
+               serializer: serializer
+             )
   end
 
   describe "read stream forward" do
@@ -204,7 +207,8 @@ defmodule EventStore.Streams.SingleStreamTest do
       stream_uuid: stream_uuid
     } do
       read_events =
-        Stream.stream_forward(conn, stream_uuid, 0, 1, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, stream_uuid, 0, read_batch_size: 1, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 3
       assert pluck(read_events, :event_number) == [1, 2, 3]
@@ -217,7 +221,8 @@ defmodule EventStore.Streams.SingleStreamTest do
       stream_uuid: stream_uuid
     } do
       read_events =
-        Stream.stream_forward(conn, stream_uuid, 0, 2, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, stream_uuid, 0, read_batch_size: 2, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 3
     end
@@ -228,7 +233,7 @@ defmodule EventStore.Streams.SingleStreamTest do
       stream_uuid: stream_uuid
     } do
       read_events =
-        Stream.stream_forward(conn, stream_uuid, 0, 1_000, serializer: serializer)
+        Stream.stream_forward(conn, stream_uuid, 0, read_batch_size: 1_000, serializer: serializer)
         |> Enum.to_list()
 
       assert length(read_events) == 3
@@ -240,7 +245,8 @@ defmodule EventStore.Streams.SingleStreamTest do
       stream_uuid: stream_uuid
     } do
       read_events =
-        Stream.stream_forward(conn, stream_uuid, 2, 1, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, stream_uuid, 2, read_batch_size: 1, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 2
       assert pluck(read_events, :event_number) == [2, 3]
@@ -250,7 +256,8 @@ defmodule EventStore.Streams.SingleStreamTest do
     test "should stream events from single stream with starting version offset outside range",
          %{conn: conn, serializer: serializer, stream_uuid: stream_uuid} do
       read_events =
-        Stream.stream_forward(conn, stream_uuid, 4, 1, serializer: serializer) |> Enum.to_list()
+        Stream.stream_forward(conn, stream_uuid, 4, read_batch_size: 1, serializer: serializer)
+        |> Enum.to_list()
 
       assert length(read_events) == 0
     end

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -7,7 +7,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   alias TestEventStore, as: EventStore
 
   @event_store TestEventStore
-  @conn TestEventStore.EventStore.Postgrex
+  @conn TestEventStore.Postgrex
 
   setup do
     subscription_name = UUID.uuid4()

--- a/test/subscriptions/subscription_locking_test.exs
+++ b/test/subscriptions/subscription_locking_test.exs
@@ -4,7 +4,7 @@ defmodule EventStore.Subscriptions.SubscriptionLockingTest do
   alias EventStore.{Config, EventFactory, ProcessHelper, Storage}
   alias EventStore.Subscriptions.Subscription
 
-  @conn TestEventStore.EventStore.Postgrex
+  @conn TestEventStore.Postgrex
 
   setup do
     subscription_name = UUID.uuid4()

--- a/test/subscriptions/support/stream_subscription_test_case.ex
+++ b/test/subscriptions/support/stream_subscription_test_case.ex
@@ -7,7 +7,7 @@ defmodule EventStore.Subscriptions.StreamSubscriptionTestCase do
     alias EventStore.Subscriptions.SubscriptionFsm
 
     @event_store TestEventStore
-    @conn TestEventStore.EventStore.Postgrex
+    @conn TestEventStore.Postgrex
     @subscription_name "test_subscription"
 
     setup [:start_subscriber]


### PR DESCRIPTION
Allow a name to be provided when starting an event store. All event store operations can be provided with an optional name to determine the event store instance.

### Example

Define an event store:

```elixir
defmodule MyApp.EventStore do
  use EventStore, otp_app: :eventstore
end
```

Start multiple instances of the event store, each with a unique name:

```elixir
{:ok, _pid} = EventStore.start_link(name: :eventstore1)
{:ok, _pid} = EventStore.start_link(name: :eventstore2)
{:ok, _pid} = EventStore.start_link(name: :eventstore3)
```

Use an event store by providing a name:

```elixir
:ok = EventStore.append_to_stream(stream_uuid, expected_version, events, name: :eventstore1)

{:ok, events} = EventStore.read_stream_forward(stream_uuid, 0, 1_000, name: :eventstore1)
```

### Dynamic schemas

This feature also allows you to start each event store instance using a different schema:

```elixir
{:ok, _pid} = EventStore.start_link(name: :tenant1, schema: "tenant1")
{:ok, _pid} = EventStore.start_link(name: :tenant2, schema: "tenant2")
```
Or start supervised:

```elixir
children = 
  for tenant <- [:tenant1, :tenant2, :tenant3] do
    {MyApp.EventStore, name: :tenant1, schema: Atom.to_string("tenant1")}
  end

opts = [strategy: :one_for_one, name: MyApp.Supervisor]
Supervisor.start_link(children, opts)
```

The above can be used for multi-tenancy where the data for each tenant is stored in a separate schema.
