### PR TITLE
Fix DistributedForwarder State when running multiple nodes

### DIFF
--- a/lib/event_store/registration/distributed_forwarder.ex
+++ b/lib/event_store/registration/distributed_forwarder.ex
@@ -24,8 +24,8 @@ defmodule EventStore.Registration.DistributedForwarder do
     :ok
   end
 
-  def init(_args) do
-    {:ok, []}
+  def init(event_store) do
+    {:ok, event_store}
   end
 
   def handle_info({:broadcast, topic, message}, event_store) do

--- a/test/distributed_forwarder_test.exs
+++ b/test/distributed_forwarder_test.exs
@@ -1,0 +1,9 @@
+defmodule EventStore.Registration.DistributedForwarderTest do
+  use EventStore.StorageCase
+
+  test "keep given event store argument as state" do
+    {:ok, pid} = EventStore.Registration.DistributedForwarder.start_link(TestEventStore)
+
+    assert TestEventStore = :sys.get_state(pid)
+  end
+end


### PR DESCRIPTION
### Context:
I was trying to setup Commanded with Horde and EventStore and found that something the `DistributedForwarder` state was empty in some cases, raising an error such as:

```
14:27:57.931 [error] GenServer Integration.EventStore.EventStore.Registration.DistributedForwarder terminating
** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2
    (elixir) src/elixir_aliases.erl:130: :elixir_aliases.do_concat([[], EventStore.PubSub], "Elixir")
    (elixir) src/elixir_aliases.erl:118: :elixir_aliases.concat/1
    (eventstore) lib/event_store/registration/local_registry.ex:52: EventStore.Registration.LocalRegistry.broadcast/3
    (eventstore) lib/event_store/registration/distributed_forwarder.ex:36: EventStore.Registration.DistributedForwarder.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

This happens when I try to connect 3 nodes following this steps:
1. Start Node A
2. Start Node B
3. Start Node C
4. In Node C connect to Node A and B.
5. In Node C dispatch a command.

Here's a repo with a sample app that is able to reproduce the problem, the app is using SwarmRegistry:
https://github.com/scudelletti/eventstore-error

### Reasoning behind the change:

Debugging it I found that the `init/1` function initializes the state with an empty list. Setting the provided `event_store` argument seems to fix the problem.
I'm not sure where the state is set if the `init/1` function always set it to empty though.


### Others 
~I can try to provide a sample app with the problem if needed, just please let me know.~

@slashdotdash thank you for maintaining Commanded and its related libraries. 🎉 💐 ❤️ 