### PR TITLE
Prevent double supervision by starting / stopping supervisor manually

### DIFF
--- a/lib/event_store/notifications/global_runner.ex
+++ b/lib/event_store/notifications/global_runner.ex
@@ -1,0 +1,47 @@
+defmodule EventStore.Notifications.GlobalRunner do
+  use GenServer
+
+  def child_spec(child_child_spec) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, child_child_spec, []]}
+    }
+  end
+
+  def init(child_spec) do
+    Process.flag(:trap_exit, true)
+    {:ok, register(%{child_spec: child_spec})}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, _}, %{ref: ref} = state) do
+    {:noreply, register(state)}
+  end
+
+  defp name(state) do
+    %{child_spec: {_, {event_store, _, _, _}}} = state
+    {:global, Module.concat([event_store, __MODULE__])}
+  end
+
+  defp register(state) do
+    case :global.register_name(name(state), self()) do
+      :yes -> start(state)
+      :no -> monitor(state)
+    end
+  end
+
+  defp start(state) do
+    {:ok, pid} = Supervisor.start_link([state.child_spec], strategy: :one_for_one)
+    %{child_spec: state.child_spec, pid: pid}
+  end
+
+  defp monitor(state) do
+    ref = Process.monitor(name(state))
+    %{child_spec: state.child_spec, ref: ref}
+  end
+
+  def terminate(reason, %{pid: pid}) do
+    Supervisor.stop(pid, reason)
+  end
+
+  def terminate(_, _), do: nil
+end

--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -15,32 +15,8 @@ defmodule EventStore.Notifications.Supervisor do
   alias EventStore.MonitoredServer
   alias EventStore.Notifications.{Listener, Reader, Broadcaster}
 
-  @doc """
-  Starts a globally named supervisor process.
-
-  This is to ensure only a single instance of the supervisor, and its
-  supervised children, is kept running on a cluster of nodes.
-  """
-  def start_link({event_store, _registry, _serializer, _config} = args) do
-    name = {:global, Module.concat([event_store, __MODULE__])}
-
-    case Supervisor.start_link(__MODULE__, args, name: name) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      {:error, :killed} ->
-        # Process may be killed due to `:global` name registation when another node connects.
-        # Attempting to start again should link to the other named existing process.
-        start_link(args)
-
-      {:error, {:already_started, pid}} ->
-        true = Process.link(pid)
-
-        {:ok, pid}
-
-      reply ->
-        reply
-    end
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg)
   end
 
   @impl Supervisor

--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -77,7 +77,8 @@ defmodule EventStore.Supervisor do
               {Registry, keys: :unique, name: subscriptions_registry_name},
               id: subscriptions_registry_name
             ),
-            {Notifications.Supervisor, {name, registry, serializer, config}}
+            {EventStore.Notifications.GlobalRunner,
+             {Notifications.Supervisor, {name, registry, serializer, config}}}
           ] ++ Registration.child_spec(name, registry)
 
         Supervisor.init(children, strategy: :one_for_all)


### PR DESCRIPTION
This fixes a bug where each `Notification.Supervisor` was being supervised by multiple `EventStore.Supervisor` (one local, the rest remote), which is an OTP no-no (causing `EventStore.Supervisor` to block on shutdown if it was not the parent of the global `Notification.Supervisor`.

I still think this solution is a bit janky, because we're essentially inventing our own supervisor here. Please take a look and let me know what you think.