### PR TITLE
Doc Fix - Add missing comma

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -197,7 +197,7 @@ To enable native JSON support you need to configure your event store to use the 
 ```elixir
 # config/config.exs
 config :my_app, MyApp.EventStore,
-  column_data_type: "jsonb"
+  column_data_type: "jsonb",
   serializer: EventStore.JsonbSerializer,
   types: EventStore.PostgresTypes
 ```


### PR DESCRIPTION
Found this when copy/pasting and getting a syntax error. :stuck_out_tongue: 