### PR TITLE
Delete event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+### Enhancements
+
+- Delete event stream ([#203](https://github.com/commanded/eventstore/pull/203)).
+
 ## v1.1.0
 
 ### Enhancements

--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -7,10 +7,10 @@ defmodule EventStore.RecordedEvent do
 
   ## Recorded event fields
 
-    - `event_number` - position of the event within the stream. This will be
-      identical to the `stream_version` when fetching events from a single
-      stream. For the `$all` stream it will be the globally unique and ordered
-      event number.
+    - `event_number` - position of the event within the stream.
+      This will be identical to the `stream_version` when fetching events from a
+      single stream. For the `$all` stream it will be the globally ordered event
+      number.
     - `event_id` - a globally unique UUID to identify the event.
     - `stream_uuid` - the original stream identity for the event.
     - `stream_version` - the original version of the stream for the event.
@@ -18,9 +18,9 @@ defmodule EventStore.RecordedEvent do
       messages.
     - `causation_id` - an optional UUID identifier used to identify which
       message you are responding to.
-    - `data` - the serialized event as binary data.
-    - `metadata` - the serialized event metadata as binary data.
-    - `created_at` - the date/time, in UTC, indicating when the event was
+    - `data` - the deserialized event data.
+    - `metadata` - a deserialized map of event metadata.
+    - `created_at` - a `DateTime` (in UTC) indicating when the event was
       created.
 
   """
@@ -37,8 +37,8 @@ defmodule EventStore.RecordedEvent do
           correlation_id: uuid() | nil,
           causation_id: uuid() | nil,
           event_type: String.t(),
-          data: term,
-          metadata: binary() | nil,
+          data: any(),
+          metadata: map() | nil,
           created_at: DateTime.t()
         }
 

--- a/lib/event_store/storage.ex
+++ b/lib/event_store/storage.ex
@@ -6,6 +6,7 @@ defmodule EventStore.Storage do
   alias EventStore.Storage.{
     Appender,
     CreateStream,
+    DeleteStream,
     QueryStreamInfo,
     Reader,
     Snapshot,
@@ -47,6 +48,16 @@ defmodule EventStore.Storage do
   def stream_info(conn, stream_uuid, opts \\ []) do
     QueryStreamInfo.execute(conn, stream_uuid, opts)
   end
+
+  @doc """
+  Soft delete a stream by marking it as deleted.
+  """
+  defdelegate soft_delete_stream(conn, stream_id, opts), to: DeleteStream, as: :soft_delete
+
+  @doc """
+  Hard delete a stream by removing the stream and all its event.
+  """
+  defdelegate hard_delete_stream(conn, stream_id, opts), to: DeleteStream, as: :hard_delete
 
   @doc """
   Create, or locate an existing, persistent subscription to a stream using a

--- a/lib/event_store/storage/delete_stream.ex
+++ b/lib/event_store/storage/delete_stream.ex
@@ -1,0 +1,64 @@
+defmodule EventStore.Storage.DeleteStream do
+  @moduledoc false
+
+  require Logger
+
+  alias EventStore.Sql.Statements
+
+  def soft_delete(conn, stream_id, opts \\ []) do
+    query = Statements.soft_delete_stream()
+
+    case Postgrex.query(conn, query, [stream_id], opts) do
+      {:ok, %Postgrex.Result{num_rows: 1}} ->
+        Logger.debug(fn -> "Soft deleted stream #{inspect(stream_id)}" end)
+
+        :ok
+
+      {:ok, %Postgrex.Result{num_rows: 0}} ->
+        Logger.warn(fn ->
+          "Failed to soft delete stream #{inspect(stream_id)} due to: stream not found"
+        end)
+
+        {:error, :stream_not_found}
+
+      {:error, error} = reply ->
+        Logger.warn(fn ->
+          "Failed to soft delete stream #{inspect(stream_id)} due to: " <> inspect(error)
+        end)
+
+        reply
+    end
+  end
+
+  def hard_delete(conn, stream_id, opts \\ []) do
+    query = Statements.hard_delete_stream()
+
+    case Postgrex.query(conn, query, [stream_id], opts) do
+      {:ok, %Postgrex.Result{num_rows: 1, rows: [[^stream_id]]}} ->
+        Logger.debug(fn -> "Hard deleted stream #{inspect(stream_id)}" end)
+
+        :ok
+
+      {:ok, %Postgrex.Result{num_rows: 0}} ->
+        Logger.warn(fn ->
+          "Failed to hard delete stream #{inspect(stream_id)} due to: stream not found"
+        end)
+
+        {:error, :stream_not_found}
+
+      {:error, %Postgrex.Error{postgres: %{code: :feature_not_supported}} = error} ->
+        Logger.warn(fn ->
+          "Failed to hard delete stream #{inspect(stream_id)} due to: " <> inspect(error)
+        end)
+
+        {:error, :not_supported}
+
+      {:error, error} = reply ->
+        Logger.warn(fn ->
+          "Failed to hard delete stream #{inspect(stream_id)} due to: " <> inspect(error)
+        end)
+
+        reply
+    end
+  end
+end

--- a/lib/event_store/storage/query_stream_info.ex
+++ b/lib/event_store/storage/query_stream_info.ex
@@ -4,17 +4,17 @@ defmodule EventStore.Storage.QueryStreamInfo do
   alias EventStore.Sql.Statements
 
   def execute(conn, stream_uuid, opts \\ []) do
-    query = Statements.query_stream_id_and_latest_version()
+    query = Statements.query_stream_info()
 
     case Postgrex.query(conn, query, [stream_uuid], opts) do
       {:ok, %Postgrex.Result{num_rows: 0}} ->
-        {:ok, nil, 0}
+        {:ok, nil, 0, nil}
 
-      {:ok, %Postgrex.Result{rows: [[stream_id, nil]]}} ->
-        {:ok, stream_id, 0}
+      {:ok, %Postgrex.Result{rows: [[stream_id, nil, deleted_at]]}} ->
+        {:ok, stream_id, 0, deleted_at}
 
-      {:ok, %Postgrex.Result{rows: [[stream_id, stream_version]]}} ->
-        {:ok, stream_id, stream_version}
+      {:ok, %Postgrex.Result{rows: [[stream_id, stream_version, deleted_at]]}} ->
+        {:ok, stream_id, stream_version, deleted_at}
     end
   end
 end

--- a/lib/event_store/storage/reader.ex
+++ b/lib/event_store/storage/reader.ex
@@ -54,15 +54,15 @@ defmodule EventStore.Storage.Reader do
         ]) do
       %RecordedEvent{
         event_number: event_number,
-        event_id: event_id |> from_uuid(),
+        event_id: from_uuid(event_id),
         stream_uuid: stream_uuid,
         stream_version: stream_version,
         event_type: event_type,
-        correlation_id: correlation_id |> from_uuid(),
-        causation_id: causation_id |> from_uuid(),
+        correlation_id: from_uuid(correlation_id),
+        causation_id: from_uuid(causation_id),
         data: data,
         metadata: metadata,
-        created_at: created_at |> from_timestamp()
+        created_at: from_timestamp(created_at)
       }
     end
 
@@ -72,7 +72,7 @@ defmodule EventStore.Storage.Reader do
     defp from_timestamp(%DateTime{} = timestamp), do: timestamp
 
     defp from_timestamp(%NaiveDateTime{} = timestamp) do
-      timestamp |> DateTime.from_naive("Etc/UTC")
+      DateTime.from_naive(timestamp, "Etc/UTC")
     end
 
     if Code.ensure_loaded?(Postgrex.Timestamp) do

--- a/lib/event_store/storage/subscription.ex
+++ b/lib/event_store/storage/subscription.ex
@@ -27,10 +27,7 @@ defmodule EventStore.Storage.Subscription do
     do: Subscription.All.execute(conn, opts)
 
   def subscribe_to_stream(conn, stream_uuid, subscription_name, start_from, opts \\ []) do
-    with {:ok, subscription} <-
-           Subscription.Query.execute(conn, stream_uuid, subscription_name, opts) do
-      {:ok, subscription}
-    else
+    case Subscription.Query.execute(conn, stream_uuid, subscription_name, opts) do
       {:error, :subscription_not_found} ->
         create_subscription(conn, stream_uuid, subscription_name, start_from, opts)
 

--- a/lib/event_store/streams/stream_info.ex
+++ b/lib/event_store/streams/stream_info.ex
@@ -1,0 +1,52 @@
+defmodule EventStore.Streams.StreamInfo do
+  alias EventStore.Storage
+  alias EventStore.Streams.StreamInfo
+
+  defstruct [:stream_uuid, :stream_id, :deleted_at, stream_version: 0]
+
+  def new(stream_uuid, stream_id, stream_version, deleted_at) do
+    %StreamInfo{
+      stream_uuid: stream_uuid,
+      stream_id: stream_id,
+      stream_version: stream_version,
+      deleted_at: deleted_at
+    }
+  end
+
+  def read(conn, stream_uuid, expected_version, opts) do
+    with {:ok, stream_id, stream_version, deleted_at} <-
+           Storage.stream_info(conn, stream_uuid, opts),
+         stream_info = new(stream_uuid, stream_id, stream_version, deleted_at),
+         :ok <- validate_expected_version(stream_info, expected_version) do
+      {:ok, stream_info}
+    end
+  end
+
+  defp validate_expected_version(%StreamInfo{} = stream, expected_version) do
+    %StreamInfo{stream_id: stream_id, stream_version: stream_version, deleted_at: deleted_at} =
+      stream
+
+    cond do
+      not is_nil(deleted_at) ->
+        {:error, :stream_deleted}
+
+      is_nil(stream_id) and expected_version in [0, :any_version, :no_stream] ->
+        :ok
+
+      is_nil(stream_id) and expected_version == :stream_exists ->
+        {:error, :stream_not_found}
+
+      not is_nil(stream_id) and expected_version in [stream_version, :any_version, :stream_exists] ->
+        :ok
+
+      not is_nil(stream_id) and stream_version == 0 and expected_version == :no_stream ->
+        :ok
+
+      not is_nil(stream_id) and stream_version != 0 and expected_version == :no_stream ->
+        {:error, :stream_exists}
+
+      true ->
+        {:error, :wrong_expected_version}
+    end
+  end
+end

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -22,6 +22,6 @@ defmodule EventStore.Subscriptions.SubscriptionState do
     buffer_size: 1,
     subscribers: %{},
     partitions: %{},
-    processed_event_ids: MapSet.new()
+    processed_event_numbers: MapSet.new()
   ]
 end

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -13,7 +13,8 @@ defmodule EventStore.Tasks.Migrate do
     "0.13.0",
     "0.14.0",
     "0.17.0",
-    "1.1.0"
+    "1.1.0",
+    "1.2.0"
   ]
 
   @dialyzer {:no_return, exec: 2, handle_response: 1}

--- a/priv/event_store/migrations/v1.2.0.sql
+++ b/priv/event_store/migrations/v1.2.0.sql
@@ -1,0 +1,73 @@
+DO $migration$
+BEGIN
+
+  -- Drop no UPDATE and DELETE rules to be replaced with triggers
+  DROP RULE no_update_stream_events ON stream_events;
+  DROP RULE no_delete_stream_events ON stream_events;
+  DROP RULE no_update_events ON events;
+  DROP RULE no_delete_events ON events;
+
+  CREATE OR REPLACE FUNCTION event_store_exception()
+    RETURNS trigger AS $$
+  DECLARE
+    message text;
+  BEGIN
+    message := 'EventStore: ' || TG_ARGV[0];
+
+    RAISE EXCEPTION USING MESSAGE = message;
+  END;
+  $$ LANGUAGE plpgsql;
+
+  CREATE OR REPLACE FUNCTION event_store_delete()
+    RETURNS trigger AS $$
+  DECLARE
+    message text;
+  BEGIN
+    IF current_setting('eventstore.enable_hard_deletes', true) = 'on' OR
+      current_setting('eventstore.reset', true) = 'on'
+    THEN
+      -- Allow DELETE
+      RETURN OLD;
+    ELSE
+      -- Prevent DELETE
+      message := 'EventStore: ' || TG_ARGV[0];
+
+      RAISE EXCEPTION USING MESSAGE = message, ERRCODE = 'feature_not_supported';
+    END IF;
+  END;
+  $$ LANGUAGE plpgsql;
+
+  -- Create UPDATE and DELETE triggers
+  CREATE TRIGGER no_update_events
+    BEFORE UPDATE ON events
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE event_store_exception('Cannot update events');
+
+  CREATE TRIGGER no_delete_events
+    BEFORE DELETE ON events
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE event_store_delete('Cannot delete events');
+
+  CREATE TRIGGER no_update_stream_events
+      BEFORE UPDATE ON stream_events
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE event_store_exception('Cannot update stream events');
+
+  CREATE TRIGGER no_delete_stream_events
+    BEFORE DELETE ON stream_events
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE event_store_delete('Cannot delete stream events');
+
+  CREATE TRIGGER no_delete_events
+    BEFORE DELETE ON streams
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE event_store_delete('Cannot delete streams');
+
+  -- Streams now require a `deleted_at` column
+  ALTER TABLE streams ADD COLUMN deleted_at timestamp with time zone;
+
+  -- Record schema migration
+  INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (1, 2, 0);
+
+END;
+$migration$ LANGUAGE plpgsql;

--- a/test/append_to_stream_test.exs
+++ b/test/append_to_stream_test.exs
@@ -53,11 +53,11 @@ defmodule EventStore.AppendToStreamTest do
   end
 
   describe "append to new stream using `:stream_exists`" do
-    test "should return `{:error, :stream_does_not_exist}`" do
+    test "should return `{:error, :stream_not_found}`" do
       stream_uuid = UUID.uuid4()
       events = EventFactory.create_events(3)
 
-      assert {:error, :stream_does_not_exist} =
+      assert {:error, :stream_not_found} =
                EventStore.append_to_stream(stream_uuid, :stream_exists, events)
     end
   end

--- a/test/migrated_event_store_test.exs
+++ b/test/migrated_event_store_test.exs
@@ -22,7 +22,7 @@ defmodule MigratedEventStoreTest do
     recreate_database(config)
     migrate_eventstore(config)
 
-    {:ok, _pid} = TestEventStore.start_link()
+    start_supervised!(TestEventStore)
 
     :ok
   end

--- a/test/storage/protect_against_update_and_delete_test.exs
+++ b/test/storage/protect_against_update_and_delete_test.exs
@@ -1,0 +1,45 @@
+defmodule EventStore.Storage.ProtectAgainstUpdateAndDeleteTest do
+  use EventStore.StorageCase
+
+  alias EventStore.Config
+
+  describe "event store table protection" do
+    test "cannot delete from `events`, `streams`, and `stream_events` tables", %{conn: conn} do
+      for table <- ["events", "streams", "stream_events"] do
+        assert_cannot_delete(conn, table)
+      end
+    end
+
+    test "cannot update `events` table", %{conn: conn} do
+      assert {:error, %Postgrex.Error{postgres: %{message: "EventStore: Cannot update events"}}} =
+               Postgrex.query(conn, "UPDATE events SET created_at = NOW();", [])
+    end
+
+    test "cannot update `stream_events` table", %{conn: conn} do
+      assert {:error,
+              %Postgrex.Error{postgres: %{message: "EventStore: Cannot update stream events"}}} =
+               Postgrex.query(conn, "UPDATE stream_events SET stream_id = 1;", [])
+    end
+
+    defp assert_cannot_delete(conn, table) do
+      expected_message = "EventStore: Cannot delete #{String.replace(table, "_", " ")}"
+
+      assert {:error, %Postgrex.Error{postgres: %{message: ^expected_message}}} =
+               Postgrex.query(conn, "DELETE FROM #{table};", [])
+    end
+  end
+
+  describe "event store enable hard deletes" do
+    test "can delete from `events`, `streams`, and `stream_events` tables" do
+      config =
+        TestEventStore.config(enable_hard_deletes: true)
+        |> Config.default_postgrex_opts()
+
+      conn = start_supervised!({Postgrex, config})
+
+      for table <- ["events", "streams", "stream_events"] do
+        assert {:ok, %Postgrex.Result{}} = Postgrex.query(conn, "DELETE FROM #{table};", [])
+      end
+    end
+  end
+end

--- a/test/storage/stream_persistence_test.exs
+++ b/test/storage/stream_persistence_test.exs
@@ -23,7 +23,7 @@ defmodule EventStore.Storage.StreamPersistenceTest do
 
     {:ok, stream_id} = CreateStream.execute(conn, stream_uuid)
 
-    assert {:ok, ^stream_id, 0} = QueryStreamInfo.execute(conn, stream_uuid)
+    assert {:ok, ^stream_id, 0, nil} = QueryStreamInfo.execute(conn, stream_uuid)
   end
 
   test "stream info for stream with one event", %{conn: conn} do
@@ -31,14 +31,14 @@ defmodule EventStore.Storage.StreamPersistenceTest do
 
     {:ok, stream_id} = create_stream_with_events(conn, stream_uuid, 1)
 
-    assert {:ok, ^stream_id, 1} = QueryStreamInfo.execute(conn, stream_uuid)
+    assert {:ok, ^stream_id, 1, nil} = QueryStreamInfo.execute(conn, stream_uuid)
   end
 
   test "stream info for stream with some events", %{conn: conn} do
     stream_uuid = UUID.uuid4()
     {:ok, stream_id} = create_stream_with_events(conn, stream_uuid, 3)
 
-    assert {:ok, ^stream_id, 3} = QueryStreamInfo.execute(conn, stream_uuid)
+    assert {:ok, ^stream_id, 3, nil} = QueryStreamInfo.execute(conn, stream_uuid)
   end
 
   test "stream info for additional stream with some events", %{conn: conn} do
@@ -48,14 +48,14 @@ defmodule EventStore.Storage.StreamPersistenceTest do
     {:ok, first_stream_id} = create_stream_with_events(conn, first_stream_uuid, 3)
     {:ok, second_stream_id} = create_stream_with_events(conn, second_stream_uuid, 2, 4)
 
-    assert {:ok, ^first_stream_id, 3} = QueryStreamInfo.execute(conn, first_stream_uuid)
-    assert {:ok, ^second_stream_id, 2} = QueryStreamInfo.execute(conn, second_stream_uuid)
+    assert {:ok, ^first_stream_id, 3, nil} = QueryStreamInfo.execute(conn, first_stream_uuid)
+    assert {:ok, ^second_stream_id, 2, nil} = QueryStreamInfo.execute(conn, second_stream_uuid)
   end
 
   test "stream info for an unknown stream", %{conn: conn} do
     stream_uuid = UUID.uuid4()
 
-    assert {:ok, nil, 0} = QueryStreamInfo.execute(conn, stream_uuid)
+    assert {:ok, nil, 0, nil} = QueryStreamInfo.execute(conn, stream_uuid)
   end
 
   defp create_stream_with_events(conn, stream_uuid, number_of_events, initial_event_number \\ 1) do

--- a/test/streams/hard_delete_stream_test.exs
+++ b/test/streams/hard_delete_stream_test.exs
@@ -1,0 +1,239 @@
+defmodule EventStore.Streams.HardDeleteStreamTest do
+  use EventStore.StorageCase
+
+  alias EventStore.EventFactory
+  alias EventStore.ProcessHelper
+  alias EventStore.RecordedEvent
+  alias TestEventStore, as: EventStore
+
+  describe "hard delete stream when enabled" do
+    setup [:enable_hard_deletes, :append_events_to_stream]
+
+    test "should succeed when stream exists", %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, :stream_exists, :hard)
+    end
+
+    test "should succeed when stream exists for any expected version", %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+    end
+
+    test "should succeed when stream exists and expected version matches",
+         %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, 3, :hard)
+    end
+
+    test "should fail when stream exists, but expected version does not match",
+         %{stream_uuid: stream_uuid} do
+      assert {:error, :wrong_expected_version} = EventStore.delete_stream(stream_uuid, 1, :hard)
+    end
+
+    test "should fail when stream does not exist" do
+      assert {:error, :stream_not_found} =
+               EventStore.delete_stream("unknown", :any_version, :hard)
+    end
+
+    test "should fail when stream already soft deleted", %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      assert {:error, :stream_deleted} =
+               EventStore.delete_stream(stream_uuid, :any_version, :hard)
+    end
+
+    test "should fail with stream not found when stream already hard deleted",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      assert {:error, :stream_not_found} =
+               EventStore.delete_stream(stream_uuid, :any_version, :hard)
+    end
+
+    test "reading from a hard deleted stream should return stream not found error",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      assert {:error, :stream_not_found} = EventStore.read_stream_forward(stream_uuid)
+      assert {:error, :stream_not_found} = EventStore.stream_forward(stream_uuid)
+    end
+
+    test "should allow writing to a hard deleted stream as if it had never existed",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      events = EventFactory.create_events(1)
+
+      assert :ok = EventStore.append_to_stream(stream_uuid, 0, events)
+    end
+
+    test "should prevent deleting global `$all` events stream" do
+      assert {:error, :cannot_delete_all_stream} =
+               EventStore.delete_stream("$all", :any_version, :hard)
+    end
+
+    test "should not delete other stream events", %{stream_uuid: stream1_uuid} do
+      stream2_uuid = UUID.uuid4()
+      stream3_uuid = UUID.uuid4()
+
+      :ok = EventStore.append_to_stream(stream2_uuid, 0, EventFactory.create_events(2))
+      :ok = EventStore.append_to_stream(stream3_uuid, 0, EventFactory.create_events(1))
+
+      :ok = EventStore.delete_stream(stream2_uuid, :any_version, :hard)
+
+      assert {:error, :stream_not_found} = EventStore.read_stream_forward(stream2_uuid)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream1_uuid)
+      assert length(events) == 3
+
+      {:ok, events} = EventStore.read_stream_forward(stream3_uuid)
+      assert length(events) == 1
+
+      {:ok, events} = EventStore.read_all_streams_forward()
+      assert length(events) == 4
+    end
+
+    test "persistent subscription to deleted stream should not receive any events",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, "test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      refute_receive {:events, _events}
+    end
+
+    test "persistent subscription to all streams should not receive deleted events",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_all_streams("test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      refute_receive {:events, _events}
+    end
+
+    test "persistent subscription to all streams should receive events appended after deleted events",
+         %{stream_uuid: stream1_uuid} do
+      :ok = EventStore.delete_stream(stream1_uuid, :any_version, :hard)
+
+      stream2_uuid = UUID.uuid4()
+      events = EventFactory.create_events(1)
+
+      :ok = EventStore.append_to_stream(stream2_uuid, 0, events)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_all_streams("test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, [event]}
+
+      assert match?(%RecordedEvent{stream_uuid: ^stream2_uuid, event_number: 4}, event)
+
+      :ok = EventStore.ack(subscription, event)
+
+      refute_receive {:events, _events}
+    end
+
+    test "resumed persistent subscription to all streams should not receive deleted events",
+         %{stream_uuid: stream1_uuid} do
+      {:ok, subscription} =
+        EventStore.subscribe_to_all_streams("test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, [event]}
+
+      assert match?(%RecordedEvent{stream_uuid: ^stream1_uuid, event_number: 1}, event)
+
+      :ok = EventStore.ack(subscription, event)
+
+      assert_receive {:events, [event]}
+      assert match?(%RecordedEvent{stream_uuid: ^stream1_uuid, event_number: 2}, event)
+
+      :ok = EventStore.delete_stream(stream1_uuid, :any_version, :hard)
+
+      ProcessHelper.shutdown(subscription)
+
+      # Resumed subscription should not receive event #2 and #3 from deleted stream
+      {:ok, subscription} =
+        EventStore.subscribe_to_all_streams("test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      refute_receive {:events, _events}
+
+      stream2_uuid = UUID.uuid4()
+      events = EventFactory.create_events(1)
+
+      :ok = EventStore.append_to_stream(stream2_uuid, 0, events)
+
+      assert_receive {:events, [event]}
+      assert match?(%RecordedEvent{stream_uuid: ^stream2_uuid, event_number: 4}, event)
+    end
+
+    test "reading all streams should not include events from deleted stream",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :hard)
+
+      assert {:ok, []} = EventStore.read_all_streams_forward()
+    end
+
+    test "reading all streams should include events appended after deleted events",
+         %{stream_uuid: stream1_uuid} do
+      :ok = EventStore.delete_stream(stream1_uuid, :any_version, :hard)
+
+      stream2_uuid = UUID.uuid4()
+      events = EventFactory.create_events(1)
+
+      :ok = EventStore.append_to_stream(stream2_uuid, 0, events)
+
+      assert {:ok, [event]} = EventStore.read_all_streams_forward()
+
+      assert match?(%RecordedEvent{stream_uuid: ^stream2_uuid, event_number: 4}, event)
+    end
+
+    test "reading a stream should not include linked events from deleted stream",
+         %{stream_uuid: stream1_uuid} do
+      stream2_uuid = UUID.uuid4()
+
+      {:ok, events} = EventStore.read_stream_forward(stream1_uuid)
+
+      :ok = EventStore.link_to_stream(stream2_uuid, 0, events)
+
+      :ok = EventStore.delete_stream(stream1_uuid, :any_version, :hard)
+
+      assert {:ok, []} = EventStore.read_stream_forward(stream2_uuid)
+    end
+  end
+
+  describe "hard delete stream when disabled" do
+    setup [:disable_hard_deletes, :append_events_to_stream]
+
+    test "should fail when stream exists", %{stream_uuid: stream_uuid} do
+      assert {:error, :not_supported} =
+               EventStore.delete_stream(stream_uuid, :stream_exists, :hard)
+    end
+  end
+
+  defp enable_hard_deletes(_context) do
+    restart_event_store_with_config(enable_hard_deletes: true)
+  end
+
+  defp disable_hard_deletes(_context) do
+    restart_event_store_with_config(enable_hard_deletes: false)
+  end
+
+  defp restart_event_store_with_config(config) do
+    stop_supervised!(TestEventStore)
+    start_supervised!({TestEventStore, config})
+
+    :ok
+  end
+
+  defp append_events_to_stream(_context) do
+    stream_uuid = UUID.uuid4()
+    events = EventFactory.create_events(3)
+
+    :ok = EventStore.append_to_stream(stream_uuid, 0, events)
+
+    [stream_uuid: stream_uuid, events: events]
+  end
+end

--- a/test/streams/soft_delete_stream_test.exs
+++ b/test/streams/soft_delete_stream_test.exs
@@ -1,0 +1,130 @@
+defmodule EventStore.Streams.SoftDeleteStreamTest do
+  use EventStore.StorageCase
+
+  alias EventStore.EventFactory
+  alias EventStore.RecordedEvent
+  alias TestEventStore, as: EventStore
+
+  describe "soft delete stream" do
+    setup [:append_events_to_stream]
+
+    test "should succeed when stream exists", %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, :stream_exists, :soft)
+    end
+
+    test "should succeed when stream exists for any expected version", %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+    end
+
+    test "should succeed when stream exists and expected version matches",
+         %{stream_uuid: stream_uuid} do
+      assert :ok = EventStore.delete_stream(stream_uuid, 3, :soft)
+    end
+
+    test "should fail when stream exists, but expected version does not match",
+         %{stream_uuid: stream_uuid} do
+      assert {:error, :wrong_expected_version} = EventStore.delete_stream(stream_uuid, 1, :soft)
+    end
+
+    test "should fail when stream does not exist" do
+      assert {:error, :stream_not_found} =
+               EventStore.delete_stream("unknown", :any_version, :soft)
+    end
+
+    test "should fail when stream already deleted", %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      assert {:error, :stream_deleted} =
+               EventStore.delete_stream(stream_uuid, :any_version, :soft)
+    end
+
+    test "should prevent reading from a deleted stream", %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      assert {:error, :stream_deleted} = EventStore.read_stream_forward(stream_uuid)
+      assert {:error, :stream_deleted} = EventStore.stream_forward(stream_uuid)
+    end
+
+    test "should prevent writing to a deleted stream", %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      events = EventFactory.create_events(1)
+
+      assert {:error, :stream_deleted} = EventStore.append_to_stream(stream_uuid, 3, events)
+    end
+
+    test "should prevent deleting global `$all` events stream" do
+      assert {:error, :cannot_delete_all_stream} =
+               EventStore.delete_stream("$all", :any_version, :soft)
+    end
+
+    test "persistent subscription to deleted stream should not receive any events",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, "test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+      refute_receive {:events, _events}
+    end
+
+    test "persistent subscription to all streams will receive deleted events",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_all_streams("test", self(), start_from: :origin)
+
+      assert_receive {:subscribed, ^subscription}
+
+      for event_number <- 1..3 do
+        assert_receive {:events, [event]}
+
+        assert match?(
+                 %RecordedEvent{event_number: ^event_number, stream_uuid: ^stream_uuid},
+                 event
+               )
+
+        :ok = EventStore.ack(subscription, event)
+      end
+
+      refute_receive {:events, _events}
+    end
+
+    test "reading all streams will include events from deleted stream",
+         %{stream_uuid: stream_uuid} do
+      :ok = EventStore.delete_stream(stream_uuid, :any_version, :soft)
+
+      assert {:ok, events} = EventStore.read_all_streams_forward()
+      assert length(events) == 3
+
+      for event <- events do
+        assert match?(%RecordedEvent{stream_uuid: ^stream_uuid}, event)
+      end
+    end
+
+    test "reading a stream will include linked events from deleted stream",
+         %{stream_uuid: stream1_uuid} do
+      stream2_uuid = UUID.uuid4()
+
+      {:ok, events} = EventStore.read_stream_forward(stream1_uuid)
+
+      :ok = EventStore.link_to_stream(stream2_uuid, 0, events)
+
+      :ok = EventStore.delete_stream(stream1_uuid, :any_version, :soft)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream2_uuid)
+      assert length(events) == 3
+    end
+  end
+
+  defp append_events_to_stream(_context) do
+    stream_uuid = UUID.uuid4()
+    events = EventFactory.create_events(3)
+
+    :ok = EventStore.append_to_stream(stream_uuid, 0, events)
+
+    [stream_uuid: stream_uuid, events: events]
+  end
+end

--- a/test/support/storage_case.ex
+++ b/test/support/storage_case.ex
@@ -35,7 +35,7 @@ defmodule EventStore.StorageCase do
   setup %{conn: conn} do
     Storage.Initializer.reset!(conn)
 
-    start_supervised!({@event_store, name: @event_store})
+    start_supervised!(@event_store)
 
     :ok
   end


### PR DESCRIPTION
Allow soft or hard deletion of an event stream.

### Soft delete 

Will mark the stream as deleted, but will _not_ delete its events.  Events from soft deleted streams will still appear in the globally ordered all events (`$all`) stream and in any linked  streams.

A soft deleted stream cannot be read nor appended to. Subscriptions to the deleted stream will not receive any events.

### Hard delete 

Will permanently delete the stream and its events. This is irreversible and will remove data. Events will be removed from the globally ordered all events stream and any linked streams.

After being hard deleted, a stream can later be appended to and read as if had never existed.

### Examples

#### Soft delete a stream

Delete a stream at any version:

```elixir
:ok = MyApp.EventStore.delete_stream("stream1", :any_version, :soft)
````

Delete a stream at an expected version:

```elixir
:ok = MyApp.EventStore.delete_stream("stream2", 3, :soft)
````

Delete stream will use soft delete by default so you can omit the type:

```elixir
:ok = MyApp.EventStore.delete_stream("stream1", :any_version)
```

#### Hard delete a stream

Since hard deletes are destructive and irreversible they are disabled by default. To use hard deletes you must first enable them for the event store:

```elixir
defmodule MyApp.EventStore do
  use EventStore, otp_app: :my_app, enable_hard_deletes: true
end
```

Or via config:

```elixir
config :my_app, MyApp.EventStore, enable_hard_deletes: true
```

Hard delete a stream:

```elixir
:ok = MyApp.EventStore.delete_stream("stream2", :stream_exists, :hard)
```

Fixes #170.