### PR TITLE
Use database lock to prevent migrations from running concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support Postgres schemas ([#182](https://github.com/commanded/eventstore/pull/182)).
 - Dynamic event store ([#184](https://github.com/commanded/eventstore/pull/184)).
 - Add `timeout` option to config ([#189](https://github.com/commanded/eventstore/pull/189)).
+- Use database lock to prevent migrations from running concurrently ([#204](https://github.com/commanded/eventstore/pull/204)).
 
 ### Upgrading
 

--- a/test/migrate_event_store_test.exs
+++ b/test/migrate_event_store_test.exs
@@ -1,0 +1,52 @@
+defmodule MigrateEventStoreTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  @moduletag :migration
+
+  setup_all do
+    config = TestEventStore.config()
+
+    restore_pre_migration_event_store(config)
+
+    [config: config]
+  end
+
+  describe "migrate event store" do
+    test "should prevent migrations from running concurrently", %{config: config} do
+      log =
+        [
+          Task.async(fn ->
+            capture_io(fn -> migrate_eventstore(config, quiet: false, is_mix: false) end)
+          end),
+          Task.async(fn ->
+            capture_io(fn -> migrate_eventstore(config, quiet: false, is_mix: false) end)
+          end),
+          Task.async(fn ->
+            capture_io(fn -> migrate_eventstore(config, quiet: false, is_mix: false) end)
+          end)
+        ]
+        |> Enum.map(&Task.await/1)
+        |> Enum.sort()
+
+      # One migration should succeed, two should be prevented due to already running
+      assert Enum.at(log, 0) =~ "EventStore database migration already in progress."
+      assert Enum.at(log, 1) =~ "EventStore database migration already in progress."
+      assert Enum.at(log, 2) =~ "The EventStore database has been migrated."
+
+      assert length(log) == 3
+    end
+  end
+
+  defp restore_pre_migration_event_store(config) do
+    EventStore.Storage.Database.drop(config)
+    :ok = EventStore.Storage.Database.create(config)
+
+    {_, 0} = EventStore.Storage.Database.restore(config, "test/fixture/eventstore.dump")
+  end
+
+  defp migrate_eventstore(config, opts) do
+    EventStore.Tasks.Migrate.exec(config, opts)
+  end
+end

--- a/test/migrated_event_store_test.exs
+++ b/test/migrated_event_store_test.exs
@@ -8,7 +8,7 @@ defmodule Snapshot do
   defstruct [:data, version: "1"]
 end
 
-defmodule MigratedStoreTest do
+defmodule MigratedEventStoreTest do
   use ExUnit.Case
 
   alias EventStore.RecordedEvent

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -9,7 +9,7 @@ defmodule SchemaTest do
     config = SchemaEventStore.config()
     postgrex_config = Config.default_postgrex_opts(config)
 
-    {:ok, conn} = Postgrex.start_link(postgrex_config)
+    conn = start_supervised!({Postgrex, postgrex_config}, id: :schema_conn)
 
     [schema_conn: conn]
   end

--- a/test/subscriptions/support/stream_subscription_test_case.ex
+++ b/test/subscriptions/support/stream_subscription_test_case.ex
@@ -506,13 +506,9 @@ defmodule EventStore.Subscriptions.StreamSubscriptionTestCase do
         |> EventStore.Config.parsed(:eventstore)
         |> EventStore.Config.sync_connect_postgrex_opts()
 
-      {:ok, conn} = Postgrex.start_link(config)
+      conn = start_supervised!({Postgrex, config})
 
       EventStore.Storage.Lock.try_acquire_exclusive_lock(conn, 1)
-
-      on_exit(fn ->
-        ProcessHelper.shutdown(conn)
-      end)
 
       [conn2: conn]
     end

--- a/test/support/storage_case.ex
+++ b/test/support/storage_case.ex
@@ -20,7 +20,7 @@ defmodule EventStore.StorageCase do
       init_eventstores()
     end
 
-    {:ok, conn} = Postgrex.start_link(postgrex_config)
+    conn = start_supervised!({Postgrex, postgrex_config})
 
     [
       conn: conn,

--- a/test/support/storage_initializer.ex
+++ b/test/support/storage_initializer.ex
@@ -8,6 +8,8 @@ defmodule EventStore.StorageInitializer do
     with {:ok, conn} <- Postgrex.start_link(config) do
       Initializer.reset!(conn)
 
+      :ok = GenServer.stop(conn)
+
       :ok
     end
   end


### PR DESCRIPTION
Use Postgres advisory lock when migrating an event store database to ensure only a single migration can run at a time. This protects against running migrations concurrently by mistake.

A database lock is used to ensure only one migration can run at a time, preventing issues with multi-node deployments where the migration is automatically run on startup where two or more nodes starting at the same time may attempt to migrate simultaneously.

Fixes #192.