### PR TITLE
Introduce migrations task to list migration status

### DIFF
--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -8,14 +8,7 @@ defmodule EventStore.Tasks.Migrate do
   alias EventStore.Storage
   alias EventStore.Config
   alias EventStore.Storage.Database
-
-  @available_migrations [
-    "0.13.0",
-    "0.14.0",
-    "0.17.0",
-    "1.1.0",
-    "1.2.0"
-  ]
+  alias EventStore.Tasks.Migrations
 
   @dialyzer {:no_return, exec: 2, handle_response: 1}
 
@@ -68,13 +61,13 @@ defmodule EventStore.Tasks.Migrate do
     case event_store_schema_version(config) do
       %Version{} = event_store_version ->
         # Only run newer migrations
-        Enum.filter(@available_migrations, fn migration_version ->
+        Enum.filter(Migrations.available_migrations(), fn migration_version ->
           migration_version |> Version.parse!() |> Version.compare(event_store_version) == :gt
         end)
 
       nil ->
         # Run all migrations
-        @available_migrations
+        Migrations.available_migrations()
     end
   end
 

--- a/lib/event_store/tasks/migrations.ex
+++ b/lib/event_store/tasks/migrations.ex
@@ -44,9 +44,11 @@ defmodule EventStore.Tasks.Migrations do
 
     Enum.each(migrations, &list_migration(&1, opts))
 
-    migrations
-    |> Enum.all?(& &1.state == :completed)
-    |> exit_normally()
+    if opts[:is_mix] do
+      migrations
+      |> Enum.all?(&(&1.state == :completed))
+      |> exit_normally()
+    end
   end
 
   @doc false

--- a/lib/event_store/tasks/migrations.ex
+++ b/lib/event_store/tasks/migrations.ex
@@ -1,0 +1,120 @@
+defmodule EventStore.Tasks.Migration do
+  defstruct version: nil, state: :pending, migrated_at: nil
+end
+
+defmodule EventStore.Tasks.Migrations do
+  @moduledoc """
+  Task to show the migration status of EventStore
+  """
+
+  import EventStore.Tasks.Output
+
+  alias EventStore.Config
+  alias EventStore.Tasks.Migration
+
+  @available_migrations [
+    "0.13.0",
+    "0.14.0",
+    "0.17.0",
+    "1.1.0",
+    "1.2.0"
+  ]
+
+  @dialyzer {:no_return, exec: 2, handle_response: 1}
+
+  @doc """
+  Run task
+
+  ## Parameters
+  - config: the parsed EventStore config
+
+  ## Opts
+  - is_mix: set to `true` if running as part of a Mix task
+
+  """
+  def exec(config, opts) do
+    opts = Keyword.merge([is_mix: false, quiet: false], opts)
+    config = Config.default_postgrex_opts(config)
+
+    migrations = migrations(config)
+    event_store = Keyword.get(opts, :eventstore, "default")
+
+    write_info("EventStore: #{event_store}\n\n", opts)
+    write_table_header(opts)
+
+    Enum.each(migrations, &list_migration(&1, opts))
+
+    migrations
+    |> Enum.all?(& &1.state == :completed)
+    |> exit_normally()
+  end
+
+  @doc false
+  def available_migrations(), do: @available_migrations
+
+  defp exit_normally(true), do: exit(:normal)
+  defp exit_normally(false), do: exit({:shutdown, 1})
+
+  defp list_migration(%Migration{version: version, state: :pending}, opts) do
+    write_info("  #{version |> String.pad_trailing(10)}\tpending", opts)
+  end
+
+  defp list_migration(%Migration{version: version, state: :completed, migrated_at: time}, opts) do
+    write_info("  #{version |> String.pad_trailing(10)}\tcompleted\t#{time}", opts)
+  end
+
+  defp write_table_header(opts) do
+    """
+      migration     state           migrated_at
+    -------------------------------------------------------------
+    """
+    |> String.trim_trailing()
+    |> write_info(opts)
+  end
+
+  defp migrations(config) do
+    completed = query_schema_migrations(config)
+    latest_migration = completed |> Enum.reverse() |> Enum.at(0, nil)
+
+    completed ++ pending_migrations(latest_migration)
+  end
+
+  defp pending_migrations(nil), do: @available_migrations
+
+  defp pending_migrations(%Migration{state: :completed, version: event_store_version}) do
+    @available_migrations
+    |> Enum.map(fn version -> %Migration{version: version} end)
+    |> Enum.filter(fn migration ->
+      Version.compare(migration.version, event_store_version) == :gt
+    end)
+  end
+
+  defp query_schema_migrations(config) do
+    config
+    |> run_query(
+      "SELECT major_version, minor_version, patch_version, migrated_at FROM schema_migrations ORDER BY 1, 2, 3"
+    )
+    |> handle_response()
+  end
+
+  defp run_query(config, query) do
+    {:ok, conn} = Postgrex.start_link(config)
+
+    reply = Postgrex.query!(conn, query, [])
+
+    true = Process.unlink(conn)
+    true = Process.exit(conn, :shutdown)
+
+    reply
+  end
+
+  defp handle_response(%Postgrex.Result{rows: rows}) do
+    Enum.map(rows, fn [major_version, minor_version, patch_version, migrated_at] ->
+      %Migration{
+        version: "#{major_version}.#{minor_version}.#{patch_version}",
+        state: :completed,
+        migrated_at: migrated_at
+      }
+    end)
+  end
+end

--- a/lib/mix/tasks/event_store.migrations.ex
+++ b/lib/mix/tasks/event_store.migrations.ex
@@ -1,0 +1,47 @@
+defmodule Mix.Tasks.EventStore.Migrations do
+  @moduledoc """
+  Show the migration status of an existing EventStore database.
+
+  The event stores to inspect are the ones specified under the
+  `:event_stores` option in the current app configuration. However,
+  if the `-e` option is given, it replaces the `:event_stores` config.
+
+  ## Examples
+
+      mix event_store.migration -e MyApp.EventStore
+
+  ## Command line options
+
+    * `-e`, `--eventstore` - the event store to create
+
+  """
+
+  use Mix.Task
+  import Mix.EventStore
+
+  alias EventStore.Tasks.Migrations
+
+  @shortdoc "Display Migration status of an existing EventStore database"
+
+  @switches [eventstore: [:string, :keep]]
+
+  @aliases [e: :eventstore]
+
+  @doc false
+  def run(args) do
+    event_stores = parse_event_store(args)
+    {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
+
+    {:ok, _} = Application.ensure_all_started(:postgrex)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
+    Enum.each(event_stores, fn event_store ->
+      ensure_event_store(event_store, args)
+      config = event_store.config()
+
+      Migrations.exec(config, Keyword.put(opts, :is_mix, true))
+    end)
+
+    Mix.Task.reenable("event_store.migrations")
+  end
+end

--- a/lib/mix/tasks/event_store.migrations.ex
+++ b/lib/mix/tasks/event_store.migrations.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.EventStore.Migrations do
 
   ## Examples
 
-      mix event_store.migration -e MyApp.EventStore
+      mix event_store.migrations -e MyApp.EventStore
 
   ## Command line options
 

--- a/test/list_event_store_migrations_test.exs
+++ b/test/list_event_store_migrations_test.exs
@@ -1,0 +1,87 @@
+defmodule ListEventStoreMigrationsTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  @moduletag :migration
+
+  setup_all do
+    config = TestEventStore.config()
+
+    [config: config]
+  end
+
+  describe "event store with pending migrations" do
+    test "should list completed and pending migrations", %{config: config} do
+      restore_pre_migration_event_store(config)
+
+      expected = """
+      EventStore: default
+
+
+        migration     state           migrated_at
+      -------------------------------------------------------------
+        0.17.0    \tcompleted\t2020-04-28 22:15:48.922963Z
+        1.1.0     \tpending
+        1.2.0     \tpending
+      """
+
+      assert expected == list_migrations(config)
+    end
+
+    test "exits with status 1 when running via mix", %{config: config} do
+      restore_pre_migration_event_store(config)
+      assert {:shutdown, 1} == catch_exit(list_migrations(config, is_mix: true))
+    end
+  end
+
+  describe "recently created event store" do
+    test "lists migrations as completed", %{config: config} do
+      create_new_database(config)
+
+      table_header = """
+      EventStore: default
+
+
+        migration     state           migrated_at
+      -------------------------------------------------------------
+      """
+
+      output = list_migrations(config)
+      assert String.starts_with?(output, table_header)
+
+      migrations =
+        output |> String.split("\n") |> Enum.drop(5) |> Enum.filter(&(String.trim(&1) != ""))
+
+      assert Enum.all?(migrations, &String.contains?(&1, "completed"))
+    end
+
+    test "exits normally when running via mix", %{config: config} do
+      create_new_database(config)
+
+      assert :normal == catch_exit(list_migrations(config, is_mix: true))
+    end
+  end
+
+  defp create_new_database(config) do
+    :ok = EventStore.Storage.Database.drop(config)
+    :ok = EventStore.Storage.Database.create(config)
+
+    {:ok, conn} = Postgrex.start_link(config)
+
+    EventStore.Storage.Initializer.run!(TestEventStore, config, conn)
+
+    :ok = GenServer.stop(conn)
+  end
+
+  defp restore_pre_migration_event_store(config) do
+    EventStore.Storage.Database.drop(config)
+    :ok = EventStore.Storage.Database.create(config)
+
+    {_, 1} = EventStore.Storage.Database.restore(config, "test/fixture/eventstore.dump")
+  end
+
+  defp list_migrations(config, opts \\ []) do
+    capture_io(fn -> EventStore.Tasks.Migrations.exec(config, opts) end)
+  end
+end


### PR DESCRIPTION
As promised in https://github.com/commanded/eventstore/issues/206 here's a PR for adding a `migrations` task.
I decided to go with `completed` and `pending` instead of `up`/`down` as the states of migrations since as far as I can tell event store migrations are one-directional.

Output looks like this:
```
EventStore: default


  migration     state           migrated_at
-------------------------------------------------------------
  0.17.0        completed       2020-04-28 22:15:48.922963Z
  1.1.0         pending
  1.2.0         pending
```

I.e., it lists the event store name and all migrations that ran for this event store with their completion timestamp. And of course it lists the pending migrations.

When there are pending migrations the task exits with `{:shutdown, 1}` IF using mix. This makes it easy to use this task in a script to check for pending migrations.

*Note:* I move the list of known migrations into the new task and reference it from the migrate task since I think duplicating the list would be bad. We could just as well place the list in the migrate task and reference it from the migrations task instead.
There's also some duplication in how to query the migrations table, but IMHO extracting it right now would be overkill, WDYT?