### PR TITLE
Hibernate subscription process after inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Delete event stream ([#203](https://github.com/commanded/eventstore/pull/203)).
 - Introduce `mix event_store.migrations` task to list migration status ([#207](https://github.com/commanded/eventstore/pull/207)).
 - Remove distributed registry ([#210](ttps://github.com/commanded/eventstore/pull/210)).
+- Hibernate subscription process after inactivity ([#214](https://github.com/commanded/eventstore/pull/214)).
 
 ### Bug fixes
 

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -75,6 +75,11 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
       - `:schema` - define the Postgres schema to use (default: `public` schema).
       - `:timeout` - set the default database query timeout in milliseconds (default: 15,000ms).
 
+      Subscription options:
+
+      - `:subscription_retry_interval` - interval between subscription connection retry attempts (default: 60,000ms).
+      - `:subscription_hibernate_after` - subscriptions will automatically hibernate to save memory after a period of inactivity (default: 15,000ms).
+
   4. Add your event store module to the `event_stores` list for your app in mix config:
 
       ```elixir

--- a/guides/Subscriptions.md
+++ b/guides/Subscriptions.md
@@ -52,7 +52,6 @@ receive do
 end
 ```
 
-
 #### Mapping events
 
 You can provide an event mapping function that maps each `RecordedEvent` before sending it to the subscriber:

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -329,12 +329,13 @@ defmodule EventStore do
         with {start_from, opts} <- Keyword.pop(opts, :start_from, :origin),
              {:ok, start_from} <- Stream.start_from(conn, stream_uuid, start_from) do
           opts =
-            Keyword.merge(opts,
+            opts
+            |> Keyword.put_new(:hibernate_after, @subscription_hibernate_after)
+            |> Keyword.put_new(:retry_interval, @subscription_retry_interval)
+            |> Keyword.merge(
               conn: conn,
               event_store: name,
               serializer: @serializer,
-              hibernate_after: @subscription_hibernate_after,
-              retry_interval: @subscription_retry_interval,
               stream_uuid: stream_uuid,
               subscription_name: subscription_name,
               start_from: start_from

--- a/lib/event_store/monitored_server.ex
+++ b/lib/event_store/monitored_server.ex
@@ -2,7 +2,7 @@ defmodule EventStore.MonitoredServer do
   @moduledoc false
 
   # Starts a `GenServer` process using a given module-fun-args tuple.
-  # 
+  #
   # Monitors the started process and attempts to restart it on terminate using
   # an exponential backoff strategy. Allows interested processes to be informed
   # when the process terminates.
@@ -32,7 +32,8 @@ defmodule EventStore.MonitoredServer do
   end
 
   def start_link(opts) do
-    {start_opts, monitor_opts} = Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt])
+    {start_opts, monitor_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
 
     state = State.new(monitor_opts, start_opts)
 

--- a/lib/event_store/notifications/broadcaster.ex
+++ b/lib/event_store/notifications/broadcaster.ex
@@ -19,8 +19,10 @@ defmodule EventStore.Notifications.Broadcaster do
   end
 
   def start_link(opts) do
-    state = State.new(opts)
-    start_opts = Keyword.take(opts, [:name, :timeout, :debug, :spawn_opt])
+    {start_opts, broadcaster_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
+
+    state = State.new(broadcaster_opts)
 
     GenStage.start_link(__MODULE__, state, start_opts)
   end

--- a/lib/event_store/notifications/listener.ex
+++ b/lib/event_store/notifications/listener.ex
@@ -17,10 +17,11 @@ defmodule EventStore.Notifications.Listener do
   defstruct [:listen_to, :schema, :ref, demand: 0, queue: :queue.new()]
 
   def start_link(opts) do
-    listen_to = Keyword.fetch!(opts, :listen_to)
-    schema = Keyword.fetch!(opts, :schema)
+    {start_opts, listener_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
 
-    start_opts = Keyword.take(opts, [:name, :timeout, :debug, :spawn_opt])
+    listen_to = Keyword.fetch!(listener_opts, :listen_to)
+    schema = Keyword.fetch!(listener_opts, :schema)
 
     state = %Listener{listen_to: listen_to, schema: schema}
 

--- a/lib/event_store/notifications/reader.ex
+++ b/lib/event_store/notifications/reader.ex
@@ -21,8 +21,10 @@ defmodule EventStore.Notifications.Reader do
   end
 
   def start_link(opts) do
-    state = State.new(opts)
-    start_opts = Keyword.take(opts, [:name, :timeout, :debug, :spawn_opt])
+    {start_opts, reader_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
+
+    state = State.new(reader_opts)
 
     GenStage.start_link(__MODULE__, state, start_opts)
   end

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -57,4 +57,37 @@ defmodule EventStore.Subscriptions do
               " config. Expected an integer in milliseconds but got: " <> inspect(invalid)
     end
   end
+
+  @doc """
+  Get the inactivity period, in milliseconds, after which a subscription process
+  will be automatically hibernated.
+
+  From Erlang/OTP 20, subscription processes will automatically hibernate to
+  save memory after `15_000` milliseconds of inactivity. This can be changed by
+  configuring the `:subscription_hibernate_after` option for the event store
+  module.
+
+  You can also set it to `:infinity` to fully disable it.
+  """
+  def hibernate_after(event_store, config) do
+    case Keyword.get(config, :subscription_hibernate_after) do
+      interval when is_integer(interval) and interval >= 0 ->
+        interval
+
+      :infinity ->
+        :infinity
+
+      nil ->
+        # Default to 15 seconds when not configured
+        15_000
+
+      invalid ->
+        raise ArgumentError,
+          message:
+            "Invalid `:subscription_hibernate_after` setting in " <>
+              inspect(event_store) <>
+              " config. Expected an integer (in milliseconds) or `:infinity` but got: " <>
+              inspect(invalid)
+    end
+  end
 end

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -21,17 +21,19 @@ defmodule EventStore.Subscriptions.Subscription do
     :retry_interval
   ]
 
-  def start_link(opts \\ []) do
-    {start_opts, subscription_opts} = Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt])
+  def start_link(opts) do
+    {start_opts, subscription_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
 
     stream_uuid = Keyword.fetch!(subscription_opts, :stream_uuid)
     subscription_name = Keyword.fetch!(subscription_opts, :subscription_name)
+    retry_interval = Keyword.fetch!(subscription_opts, :retry_interval)
 
     state = %Subscription{
       stream_uuid: stream_uuid,
       subscription_name: subscription_name,
       subscription: SubscriptionFsm.new(stream_uuid, subscription_name, subscription_opts),
-      retry_interval: Keyword.fetch!(subscription_opts, :retry_interval)
+      retry_interval: retry_interval
     }
 
     GenServer.start_link(__MODULE__, state, start_opts)

--- a/lib/event_store/subscriptions/supervisor.ex
+++ b/lib/event_store/subscriptions/supervisor.ex
@@ -19,11 +19,10 @@ defmodule EventStore.Subscriptions.Supervisor do
 
     supervisor = Module.concat(event_store, __MODULE__)
 
-    name = {:via, Registry, registry_name(event_store, stream_uuid, subscription_name)}
-    opts = Keyword.put(opts, :name, name)
-    spec = {Subscription, opts}
+    via_name = {:via, Registry, registry_name(event_store, stream_uuid, subscription_name)}
+    opts = Keyword.put(opts, :name, via_name)
 
-    DynamicSupervisor.start_child(supervisor, spec)
+    DynamicSupervisor.start_child(supervisor, {Subscription, opts})
   end
 
   def unsubscribe_from_stream(event_store, stream_uuid, subscription_name) do

--- a/test/notifications/notifications_supervisor_test.exs
+++ b/test/notifications/notifications_supervisor_test.exs
@@ -1,0 +1,57 @@
+defmodule EventStore.Notifications.NotificationsSupervisorTest do
+  use EventStore.StorageCase
+
+  alias EventStore.{EventFactory, Notifications, PubSub, Serializer, Wait}
+  alias TestEventStore, as: EventStore
+
+  describe "notifications supervisor" do
+    setup do
+      config = TestEventStore.config() |> Keyword.put(:subscription_hibernate_after, 0)
+      serializer = Serializer.serializer(TestEventStore, config)
+
+      start_supervised!({Notifications.Supervisor, {ES, serializer, config}})
+      for child_spec <- PubSub.child_spec(ES), do: start_supervised!(child_spec)
+
+      :ok
+    end
+
+    test "hibernate processes after inactivity" do
+      listener_pid = Notifications.Supervisor.listener_name(ES) |> Process.whereis()
+      reader_name_pid = Notifications.Supervisor.reader_name(ES) |> Process.whereis()
+      broadcaster_pid = Notifications.Supervisor.broadcaster_name(ES) |> Process.whereis()
+
+      # Listener processes should be hibernated after inactivity
+      Wait.until(fn ->
+        assert_hibernated(listener_pid)
+        assert_hibernated(reader_name_pid)
+        assert_hibernated(broadcaster_pid)
+      end)
+
+      stream_uuid = "example-stream"
+
+      :ok = PubSub.subscribe(ES, stream_uuid)
+
+      # Appending events to the event store should resume listener processes
+      :ok = append_events(stream_uuid, 3)
+
+      assert_receive {:events, events}
+
+      # Listener processes should be hibernated again after inactivity
+      Wait.until(fn ->
+        assert_hibernated(listener_pid)
+        assert_hibernated(reader_name_pid)
+        assert_hibernated(broadcaster_pid)
+      end)
+    end
+  end
+
+  defp assert_hibernated(pid) do
+    assert Process.info(pid, :current_function) == {:current_function, {:erlang, :hibernate, 3}}
+  end
+
+  defp append_events(stream_uuid, count, expected_version \\ 0) do
+    events = EventFactory.create_events(count, expected_version)
+
+    EventStore.append_to_stream(stream_uuid, expected_version, events)
+  end
+end

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -297,8 +297,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       refute_receive {:events, _received_events}
     end
 
-    test "subscription process hiberated after inactivity", %{
-      serializer: serializer,
+    test "subscription process hibernated after inactivity", %{
       subscription_name: subscription_name
     } do
       stream_uuid = UUID.uuid4()
@@ -307,18 +306,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       # Create a subscription with `hibernate_after` set to 1ms so process will
       # immediately hibernate
       {:ok, subscription} =
-        Subscriptions.subscribe_to_stream(self(),
-          event_store: @event_store,
-          conn: @conn,
-          serializer: serializer,
-          hibernate_after: 1,
-          retry_interval: 1_000,
-          buffer_size: 3,
-          stream_uuid: stream_uuid,
-          subscription_name: subscription_name
-        )
-
-      assert_receive {:subscribed, ^subscription}
+        subscribe_to_stream(stream_uuid, subscription_name, self(), hibernate_after: 1)
 
       # Subscription process should be hibernated
       Wait.until(fn -> assert_hibernated(subscription) end)

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -29,6 +29,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
           event_store: @event_store,
           conn: @conn,
           serializer: serializer,
+          hibernate_after: 15_000,
           retry_interval: 1_000,
           stream_uuid: stream_uuid,
           subscription_name: subscription_name
@@ -294,6 +295,51 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert_receive_events(subscription, [14, 15])
 
       refute_receive {:events, _received_events}
+    end
+
+    test "subscription process hiberated after inactivity", %{
+      serializer: serializer,
+      subscription_name: subscription_name
+    } do
+      stream_uuid = UUID.uuid4()
+      events = EventFactory.create_events(3)
+
+      # Create a subscription with `hibernate_after` set to 1ms so process will
+      # immediately hibernate
+      {:ok, subscription} =
+        Subscriptions.subscribe_to_stream(self(),
+          event_store: @event_store,
+          conn: @conn,
+          serializer: serializer,
+          hibernate_after: 1,
+          retry_interval: 1_000,
+          buffer_size: 3,
+          stream_uuid: stream_uuid,
+          subscription_name: subscription_name
+        )
+
+      assert_receive {:subscribed, ^subscription}
+
+      # Subscription process should be hibernated
+      Wait.until(fn -> assert_hibernated(subscription) end)
+
+      # Appending events to the stream should resume the subscription's event loop
+      :ok = EventStore.append_to_stream(stream_uuid, 0, events)
+
+      assert_receive {:events, received_events}
+
+      assert pluck(received_events, :event_number) == [1, 2, 3]
+      assert pluck(received_events, :stream_uuid) == [stream_uuid, stream_uuid, stream_uuid]
+      assert pluck(received_events, :stream_version) == [1, 2, 3]
+      assert pluck(received_events, :correlation_id) == pluck(events, :correlation_id)
+      assert pluck(received_events, :causation_id) == pluck(events, :causation_id)
+      assert pluck(received_events, :event_type) == pluck(events, :event_type)
+      assert pluck(received_events, :data) == pluck(events, :data)
+      assert pluck(received_events, :metadata) == pluck(events, :metadata)
+      refute pluck(received_events, :created_at) |> Enum.any?(&is_nil/1)
+
+      # Subscription process should be hibernated again after inactivity
+      Wait.until(fn -> assert_hibernated(subscription) end)
     end
   end
 
@@ -579,6 +625,10 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
 
       assert {:ok, []} = Storage.subscriptions(@conn)
     end
+  end
+
+  defp assert_hibernated(pid) do
+    assert Process.info(pid, :current_function) == {:current_function, {:erlang, :hibernate, 3}}
   end
 
   # Append events to another stream so that for single stream subscription tests


### PR DESCRIPTION
Add the `:subscription_hibernate_after` event store config setting used by subscription processes so they will automatically hibernate to save memory after a period of inactivity.

Hibernating a process will also force a garbage collection of the process' memory. As soon as a new message is received in the process mailbox the process will be resumed. This should have minimal impact on latency but can help to reduce memory leaks caused by large binaries.

Setting the configuration value to `:infinity` will disable this behaviour.

#### Example configuration

```elixir
# config/config.exs
config :my_app, MyApp.EventStore,
  serializer: EventStore.JsonSerializer,
  username: "postgres",
  password: "postgres",
  database: "eventstore",
  hostname: "localhost",
  subscription_hibernate_after: :timer.seconds(15)
```