### PR TITLE
Transient subscriptions

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -808,7 +808,7 @@ defmodule EventStore do
               :ok | {:error, term}
 
   @doc """
-  Create a persistent subscription to a single stream.
+  Create a subscription to a single stream. By default the subscription is persistent.
 
   The `subscriber` process will be notified of each batch of events appended to
   the single stream identified by `stream_uuid`.
@@ -867,6 +867,21 @@ defmodule EventStore do
             )
           ```
 
+      - `transient` is an optional boolean flag to create a transient subscription.
+        By default this is set to `false`. If you want to create a transient
+        subscription set this flag to true. Your subscription will not be
+        persisted, so if the subscription is restarted, you will receive the events
+        again starting from `start_from`.
+
+        An example usage are short lived event handlers that keep their state in
+        memory but still want to have the guarantee to have received all events.
+
+        It's possible to create a persistent subscription with some name,
+        stop it and later create a transient subscription with the same name. The
+        transient subscription will now receive all events starting from `start_from`.
+        If you later stop this `transient` subscription and start a persistent
+        subscription again with the same name, you will receive the events again
+        as if the transient subscription never existed.
 
   The subscription will resume from the last acknowledged event if it already
   exists. It will ignore the `start_from` argument in this case.
@@ -914,7 +929,7 @@ defmodule EventStore do
               | {:error, reason :: term}
 
   @doc """
-  Create a persistent subscription to all streams.
+  Create a subscription to all streams. By default the subscription is persistent.
 
   The `subscriber` process will be notified of each batch of events appended to
   any stream.
@@ -946,6 +961,9 @@ defmodule EventStore do
         allowed to connect to the subscription. By default only one subscriber
         may connect. If too many subscribers attempt to connect to the
         subscription an `{:error, :too_many_subscribers}` is returned.
+
+      - `transient` is an optional boolean flag to create a transient subscription.
+        See `subscribe_to_stream` for the full information.
 
   The subscription will resume from the last acknowledged event if it already
   exists. It will ignore the `start_from` argument in this case.

--- a/lib/event_store/subscriptions/subscription_fsm.ex
+++ b/lib/event_store/subscriptions/subscription_fsm.ex
@@ -642,12 +642,14 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
 
     cond do
       MapSet.member?(processed_event_numbers, ack) ->
+        persist_if_not_transient = not data.transient
+
         %SubscriptionState{
           data
           | processed_event_numbers: MapSet.delete(processed_event_numbers, ack),
             last_ack: ack
         }
-        |> checkpoint_last_seen(true)
+        |> checkpoint_last_seen(persist_if_not_transient)
 
       persist ->
         Storage.Subscription.ack_last_seen_event(conn, stream_uuid, subscription_name, last_ack)

--- a/lib/event_store/subscriptions/subscription_fsm.ex
+++ b/lib/event_store/subscriptions/subscription_fsm.ex
@@ -41,6 +41,7 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
           partitions: %{},
           processed_event_numbers: MapSet.new()
       }
+
       with :ok <- subscribe_to_events(data) do
         last_seen = data.start_from
 
@@ -60,6 +61,7 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
           next_state(:initial, data)
       end
     end
+
     defevent subscribe,
       data: %SubscriptionState{} = data do
       data = %SubscriptionState{

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -21,6 +21,7 @@ defmodule EventStore.Subscriptions.SubscriptionState do
     buffer_size: 1,
     subscribers: %{},
     partitions: %{},
-    processed_event_numbers: MapSet.new()
+    processed_event_numbers: MapSet.new(),
+    transient: false
   ]
 end

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -9,8 +9,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   @event_store TestEventStore
   @conn TestEventStore.Postgrex
 
-  # @moduletag :wip
-
   setup do
     subscription_name = UUID.uuid4()
 
@@ -598,7 +596,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   end
 
   describe "restarting a transient subscription" do
-    @tag :wip
     test "should receive all events after restart", %{
       subscription_name: subscription_name
     } do
@@ -630,7 +627,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(received_events, :data) == pluck(initial_events, :data)
     end
 
-    @tag :wip
     test "should receive all events starting from start_from after restart", %{
       subscription_name: subscription_name
     } do
@@ -670,7 +666,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(received_events, :data) == pluck(new_events, :data)
     end
 
-    @tag :wip
     test "should allow to start with a transient subscription and change it to a none transient subscription",
          %{
            subscription_name: subscription_name
@@ -703,7 +698,6 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       assert pluck(received_events, :data) == pluck(initial_events, :data)
     end
 
-    @tag :wip
     test "should allow to start with a persistent subscription and later start a transient subscription with the same name",
          %{
            subscription_name: subscription_name

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -9,7 +9,7 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   @event_store TestEventStore
   @conn TestEventStore.Postgrex
 
-  #@moduletag :wip
+  # @moduletag :wip
 
   setup do
     subscription_name = UUID.uuid4()
@@ -609,7 +609,8 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
 
       :ok = EventStore.append_to_stream(stream_uuid, 0, initial_events)
 
-      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
 
       assert_receive {:subscribed, ^subscription}
       assert_receive {:events, received_events}
@@ -621,7 +622,9 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       refute Process.info(subscription)
 
       :ok = EventStore.append_to_stream(stream_uuid, 1, new_events)
-      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
 
       assert_receive {:subscribed, ^subscription}
       assert_receive {:events, received_events}
@@ -640,7 +643,8 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       :ok = EventStore.append_to_stream(stream_uuid, 0, initial_events)
       :ok = EventStore.append_to_stream(stream_uuid, 1, new_events)
 
-      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
 
       assert_receive {:subscribed, ^subscription}
       assert_receive {:events, received_events}
@@ -655,14 +659,17 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       refute Process.info(subscription)
 
       :ok = EventStore.append_to_stream(stream_uuid, 2, after_restart_events)
-      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true, start_from: 1)
+
+      {:ok, subscription} =
+        EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(),
+          transient: true,
+          start_from: 1
+        )
 
       assert_receive {:subscribed, ^subscription}
       assert_receive {:events, received_events}
       assert pluck(received_events, :data) == pluck(new_events, :data)
     end
-
-
   end
 
   describe "unsubscribe from stream" do

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -9,6 +9,8 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
   @event_store TestEventStore
   @conn TestEventStore.Postgrex
 
+  #@moduletag :wip
+
   setup do
     subscription_name = UUID.uuid4()
 
@@ -563,6 +565,104 @@ defmodule EventStore.Subscriptions.SubscribeToStreamTest do
       ProcessHelper.shutdown(subscriber3)
       ProcessHelper.shutdown(subscriber4)
     end
+  end
+
+  describe "restarting a subscription" do
+    @tag :wip
+    test "should only receive not acked events", %{
+      subscription_name: subscription_name
+    } do
+      stream_uuid = UUID.uuid4()
+      initial_events = EventFactory.create_events(1)
+      new_events = EventFactory.create_events(1, 2)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 0, initial_events)
+
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self())
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(initial_events, :data)
+
+      :ok = Subscription.ack(subscription, received_events)
+
+      Process.exit(subscription, :kill)
+      refute Process.info(subscription)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 1, new_events)
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self())
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(new_events, :data)
+    end
+  end
+
+  describe "restarting a transient subscription" do
+    @tag :wip
+    test "should receive all events after restart", %{
+      subscription_name: subscription_name
+    } do
+      stream_uuid = UUID.uuid4()
+      initial_events = EventFactory.create_events(1)
+      new_events = EventFactory.create_events(1, 2)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 0, initial_events)
+
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(initial_events, :data)
+
+      :ok = Subscription.ack(subscription, received_events)
+
+      Process.exit(subscription, :kill)
+      refute Process.info(subscription)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 1, new_events)
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(initial_events, :data)
+    end
+
+    @tag :wip
+    test "should receive all events starting from start_from after restart", %{
+      subscription_name: subscription_name
+    } do
+      stream_uuid = UUID.uuid4()
+      initial_events = EventFactory.create_events(1)
+      new_events = EventFactory.create_events(1, 2)
+      after_restart_events = EventFactory.create_events(1, 3)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 0, initial_events)
+      :ok = EventStore.append_to_stream(stream_uuid, 1, new_events)
+
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(initial_events, :data)
+
+      :ok = Subscription.ack(subscription, received_events)
+
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(new_events, :data)
+
+      Process.exit(subscription, :kill)
+      refute Process.info(subscription)
+
+      :ok = EventStore.append_to_stream(stream_uuid, 2, after_restart_events)
+      {:ok, subscription} = EventStore.subscribe_to_stream(stream_uuid, subscription_name, self(), transient: true, start_from: 1)
+
+      assert_receive {:subscribed, ^subscription}
+      assert_receive {:events, received_events}
+      assert pluck(received_events, :data) == pluck(new_events, :data)
+    end
+
+
   end
 
   describe "unsubscribe from stream" do


### PR DESCRIPTION
This feature is needed to fix: https://github.com/commanded/commanded/issues/401

TODO

* [x] check what needs to happen for to `subscribe` from a `disconnected` state
* [x] `checkpoint_last_seen` or `notify_subscribers` probably needs to be changed as well 
* [x] add more tests
* [x] add to documentation

I guess a `transient` subscription can never get in a `disconnected` state, because the `AdvisoryLocks` are only used for saved subscriptions.

In theory `checkpoint_last_seen` doesn't need to be changed, because the update statement will not fail, but changed it as well so we don't even try to update.

## To discuss

Because we don't store anything, it's possible to:

1. start a persistent subscription with name "foo"
2. have it killed and later start a transient subscription with name "foo" that receives all events again
3. later kill that transient subscription and start the persistent subscription "foo" again, this will now just resume after the lasted acked events that the persistent subscription "foo" saw.

I think this is logical, but it might surprise some users, so I'll add it to the documentation.


