### PR TITLE
Shared database connection pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove distributed registry ([#210](https://github.com/commanded/eventstore/pull/210)).
 - Hibernate subscription process after inactivity ([#214](https://github.com/commanded/eventstore/pull/214)).
 - Runtime event store configuration ((#217)[https://github.com/commanded/eventstore/pull/217]).
+- Shared database connection pools ([#216](https://github.com/commanded/eventstore/pull/216)).
 
 ### Bug fixes
 

--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -145,6 +145,32 @@ defmodule EventStore do
   The above can be used for multi-tenancy where the data for each tenant is
   stored in a separate, isolated schema.
 
+  ## Shared database connection pools
+
+  By default each event store will start its own `Postgrex` database connection
+  pool. The size of the pool is configured with the `pool_size` config option.
+
+  When you have multiple event stores running you will also end up with multiple
+  connection pools. If they are all to the same physical Postgres database then
+  it can be useful to share a single pool amongst all event stores. Use the
+  `shared_connection_pool` config option to specify a name for the shared connection
+  pool. Then configure the event stores you'd like to share the pool with the
+  same name.
+
+  This can be done in config:
+
+      # config/config.exs
+      config :my_app, MyApp.EventStore, shared_connection_pool: :shared_pool
+
+  Or when starting the event stores, such as via a `Supervisor`:
+
+      Supervisor.start_link(
+        [
+          {MyApp.EventStore, name: :eventstore1, shared_connection_pool: :shared_pool},
+          {MyApp.EventStore, name: :eventstore2, shared_connection_pool: :shared_pool},
+          {MyApp.EventStore, name: :eventstore3, shared_connection_pool: :shared_pool}
+        ], opts)
+
   ## Guides
 
   Please refer to the following guides to learn more:

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -86,9 +86,7 @@ defmodule EventStore.Config do
     Keyword.take(config, @postgrex_connection_opts)
   end
 
-  def postgrex_opts(config) do
-    {name, config} = Keyword.pop(config, :conn)
-
+  def postgrex_opts(config, name) do
     [
       pool_size: 10,
       queue_target: 50,

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -52,6 +52,27 @@ defmodule EventStore.ConfigTest do
              ]
   end
 
+  test "parse `:shared_connection_pool`" do
+    config = [
+      username: "postgres",
+      database: "eventstore_test",
+      password: "postgres",
+      shared_connection_pool: :shared_pool
+    ]
+
+    assert Config.parse(config) ==
+             [
+               enable_hard_deletes: false,
+               column_data_type: "bytea",
+               schema: "public",
+               pool: EventStore.Config.get_pool(),
+               shared_connection_pool: :shared_pool,
+               password: "postgres",
+               database: "eventstore_test",
+               username: "postgres"
+             ]
+  end
+
   test "parse socket_dir" do
     config = [
       username: "postgres",

--- a/test/dynamic_event_store_test.exs
+++ b/test/dynamic_event_store_test.exs
@@ -1,4 +1,4 @@
-defmodule DynamicEventStoreTest do
+defmodule EventStore.DynamicEventStoreTest do
   use EventStore.StorageCase
 
   alias EventStore.EventFactory

--- a/test/event_store_test.exs
+++ b/test/event_store_test.exs
@@ -1,4 +1,4 @@
-defmodule EventStoreTest do
+defmodule EventStore.EventStoreTest do
   use EventStore.StorageCase
 
   alias EventStore.{EventData, EventFactory, RecordedEvent}

--- a/test/list_event_store_migrations_test.exs
+++ b/test/list_event_store_migrations_test.exs
@@ -1,4 +1,4 @@
-defmodule ListEventStoreMigrationsTest do
+defmodule EventStore.ListEventStoreMigrationsTest do
   use ExUnit.Case
 
   import ExUnit.CaptureIO

--- a/test/migrate_event_store_test.exs
+++ b/test/migrate_event_store_test.exs
@@ -1,4 +1,4 @@
-defmodule MigrateEventStoreTest do
+defmodule EventStore.MigrateEventStoreTest do
   use ExUnit.Case
 
   import ExUnit.CaptureIO

--- a/test/migrated_event_store_test.exs
+++ b/test/migrated_event_store_test.exs
@@ -8,7 +8,7 @@ defmodule Snapshot do
   defstruct [:data, version: "1"]
 end
 
-defmodule MigratedEventStoreTest do
+defmodule EventStore.MigratedEventStoreTest do
   use ExUnit.Case
 
   alias EventStore.RecordedEvent

--- a/test/monitored_server_test.exs
+++ b/test/monitored_server_test.exs
@@ -1,96 +1,167 @@
 defmodule EventStore.MonitoredServerTest do
   use ExUnit.Case
 
-  alias EventStore.{MonitoredServer, ObservedServer, ProcessHelper, Wait}
+  alias EventStore.{MonitoredServer, ObservedServer, ProcessHelper}
 
-  test "should start process" do
-    {:ok, _pid} = start_monitored_process()
+  describe "monitored server" do
+    test "should start process" do
+      start_monitored_process!()
 
-    assert ObservedServer |> Process.whereis() |> Process.alive?()
-  end
+      assert_receive {:UP, MonitoredServer, pid}
 
-  test "should restart process after exit" do
-    {:ok, _pid} = start_monitored_process()
+      assert Process.whereis(ObservedServer) == pid
+      assert Process.alive?(pid)
+    end
 
-    pid1 = shutdown_observed_process()
+    test "should stop observed process when monitored process stopped" do
+      start_monitored_process!()
 
-    Wait.until(fn ->
-      pid2 = Process.whereis(ObservedServer)
+      assert_receive {:UP, MonitoredServer, pid}
 
-      assert pid2 != nil
+      ref = Process.monitor(pid)
+
+      :ok = stop_supervised(MonitoredServer)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+    end
+
+    test "should restart process after exit" do
+      start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, pid1}
+
+      shutdown_observed_process()
+
+      assert_receive {:UP, MonitoredServer, pid2}
+
+      assert Process.whereis(ObservedServer) == pid2
+
+      assert is_pid(pid2)
       assert pid1 != pid2
       assert Process.alive?(pid2)
-    end)
+    end
+
+    test "should retry start on failure" do
+      start_monitored_process!(start_successfully: false)
+
+      assert_receive {:init, _pid}
+      assert_receive {:init, _pid}
+      assert_receive {:init, _pid}
+    end
+
+    test "should send `:DOWN` message after process shutdown" do
+      start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, _pid1}
+      refute_receive {:DOWN, MonitoredServer, _pid, _reason}
+
+      shutdown_observed_process()
+
+      assert_receive {:DOWN, MonitoredServer, _pid, :shutdown}
+    end
+
+    test "should send `:UP` message after process restarted" do
+      start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, pid1}
+      assert pid1 == Process.whereis(ObservedServer)
+
+      shutdown_observed_process()
+
+      assert_receive {:UP, MonitoredServer, pid2}
+      assert pid2 == Process.whereis(ObservedServer)
+      assert pid1 != pid2
+    end
+
+    test "should forward calls to observed process using registered name" do
+      start_monitored_process!()
+
+      assert {:ok, :pong} = GenServer.call(MonitoredServer, :ping)
+    end
+
+    test "should forward calls to observed process using pid" do
+      pid = start_monitored_process!()
+
+      assert {:ok, :pong} = GenServer.call(pid, :ping)
+    end
+
+    test "should forward casts to observed process" do
+      pid = start_monitored_process!()
+
+      assert :ok = GenServer.cast(pid, :ping)
+
+      assert_receive :pong
+    end
+
+    test "should forward info messages to observed process" do
+      pid = start_monitored_process!()
+
+      send(pid, :ping)
+
+      assert_receive :pong
+    end
+
+    test "allow monitored process to monitor an already started process" do
+      pid = start_supervised!({ObservedServer, reply_to: self(), name: ObservedServer})
+
+      assert {:ok, :pong} = GenServer.call(pid, :ping)
+
+      monitor = start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, ^pid}
+
+      assert {:ok, :pong} = GenServer.call(monitor, :ping)
+    end
+
+    test "stopping monitored observer associated with an already started process should not terminate process" do
+      pid = start_supervised!({ObservedServer, reply_to: self(), name: ObservedServer})
+
+      start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, ^pid}
+
+      ref = Process.monitor(pid)
+
+      :ok = stop_supervised(MonitoredServer)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+    end
+
+    test "monitored observer should attempt to restart an already started process on exit" do
+      pid = start_supervised!({ObservedServer, reply_to: self(), name: ObservedServer})
+
+      start_monitored_process!()
+
+      assert_receive {:UP, MonitoredServer, ^pid}
+
+      shutdown_observed_process()
+
+      assert_receive {:DOWN, MonitoredServer, ^pid, :shutdown}
+      assert_receive {:UP, MonitoredServer, _pid1}
+    end
   end
 
-  test "should send `DOWN` message after process shutdown" do
-    {:ok, _pid} = start_monitored_process()
+  defp start_monitored_process!(opts \\ []) do
+    opts = Keyword.merge([reply_to: self(), name: ObservedServer], opts)
 
-    refute_receive {:DOWN, MonitoredServer, _pid, _reason}
-
-    _pid = shutdown_observed_process()
-
-    assert_receive {:DOWN, MonitoredServer, _pid, :shutdown}
-  end
-
-  test "should send `:UP` message after process restarted" do
-    {:ok, _pid} = start_monitored_process()
-
-    assert_receive {:UP, MonitoredServer, _pid}
-
-    _pid = shutdown_observed_process()
-
-    assert_receive {:UP, MonitoredServer, _pid}
-  end
-
-  test "should forward calls to observed process using registered name" do
-    {:ok, _pid} = start_monitored_process()
-
-    assert {:ok, :pong} = GenServer.call(MonitoredServer, :ping)
-  end
-
-  test "should forward calls to observed process" do
-    {:ok, pid} = start_monitored_process()
-
-    assert {:ok, :pong} = GenServer.call(pid, :ping)
-  end
-
-  test "should forward casts to observed process" do
-    {:ok, pid} = start_monitored_process()
-
-    assert :ok = GenServer.cast(pid, :ping)
-
-    assert_receive :pong
-  end
-
-  test "should forward sent messages to observed process" do
-    {:ok, pid} = start_monitored_process()
-
-    send(pid, :ping)
-
-    assert_receive :pong
-  end
-
-  defp start_monitored_process do
-    reply_to = self()
-
-    {:ok, pid} =
-      MonitoredServer.start_link(
-        mfa: {ObservedServer, :start_link, [[reply_to: reply_to, name: ObservedServer]]},
-        name: MonitoredServer
+    spec =
+      Supervisor.child_spec(
+        {MonitoredServer,
+         mfa: {ObservedServer, :start_link, [opts]},
+         name: MonitoredServer,
+         backoff_min: 1,
+         backoff_max: 100},
+        id: MonitoredServer
       )
+
+    pid = start_supervised!(spec)
 
     :ok = MonitoredServer.monitor(MonitoredServer)
 
-    {:ok, pid}
+    pid
   end
 
   defp shutdown_observed_process do
-    pid = Process.whereis(ObservedServer)
-
-    ProcessHelper.shutdown(pid)
-    refute Process.alive?(pid)
-
-    pid
+    ProcessHelper.shutdown(ObservedServer)
   end
 end

--- a/test/multi_event_store_test.exs
+++ b/test/multi_event_store_test.exs
@@ -1,4 +1,4 @@
-defmodule MultiEventStoreTest do
+defmodule EventStore.MultiEventStoreTest do
   use EventStore.StorageCase
 
   alias EventStore.{Config, EventData, EventFactory, RecordedEvent, Storage}

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,4 +1,4 @@
-defmodule SchemaTest do
+defmodule EventStore.SchemaTest do
   use EventStore.StorageCase
 
   alias EventStore.Config

--- a/test/shared_connection_pool_test.exs
+++ b/test/shared_connection_pool_test.exs
@@ -1,0 +1,164 @@
+defmodule EventStore.SharedConnectionPoolTest do
+  use ExUnit.Case
+
+  alias EventStore.EventFactory
+  alias EventStore.MonitoredServer
+  alias EventStore.MonitoredServer.State, as: MonitoredServerState
+  alias EventStore.Tasks.{Create, Drop, Init}
+  alias EventStore.Wait
+
+  describe "connection pool sharing" do
+    setup do
+      for schema <- ["schema1", "schema2"] do
+        config = TestEventStore.config() |> Keyword.put(:schema, schema)
+
+        Create.exec(config, quiet: true)
+        Init.exec(config, quiet: true)
+      end
+
+      start_supervised!(
+        {TestEventStore,
+         name: :eventstore1, shared_connection_pool: :shared_pool, schema: "schema1"}
+      )
+
+      start_supervised!(
+        {TestEventStore,
+         name: :eventstore2, shared_connection_pool: :shared_pool, schema: "schema2"}
+      )
+
+      start_supervised!({TestEventStore, name: :eventstore3, schema: "schema3"})
+
+      on_exit(fn ->
+        for schema <- ["schema1", "schema2", "schema3"] do
+          config = TestEventStore.config() |> Keyword.put(:schema, schema)
+
+          Drop.exec(config, quiet: true)
+        end
+      end)
+    end
+
+    test "should only start one Postgrex connection pool" do
+      # Event stores sharing a connection pool should use the same `Postgrex` conn
+      conn = Process.whereis(Module.concat([:shared_pool, Postgrex]))
+      assert is_pid(conn)
+      assert_postgrex_connection(conn)
+
+      pid1 = Process.whereis(Module.concat([:eventstore1, Postgrex, MonitoredServer]))
+
+      assert is_pid(pid1)
+      assert %MonitoredServerState{pid: ^conn} = :sys.get_state(pid1)
+
+      pid2 = Process.whereis(Module.concat([:eventstore2, Postgrex, MonitoredServer]))
+
+      assert is_pid(pid2)
+      assert %MonitoredServerState{pid: ^conn} = :sys.get_state(pid2)
+    end
+
+    test "start a separate Postgrex connection for non-shared connection pools" do
+      # An event store started without specifying a connection pool should start its own pool
+      pid = Process.whereis(Module.concat([:eventstore3, Postgrex]))
+
+      assert is_pid(pid)
+      assert_postgrex_connection(pid)
+    end
+
+    test "stopping event store with shared connection pool should start new connection" do
+      conn = Process.whereis(Module.concat([:shared_pool, Postgrex]))
+      assert is_pid(conn)
+
+      ref = Process.monitor(conn)
+
+      stop_supervised!(:eventstore1)
+
+      assert_receive {:DOWN, ^ref, :process, _object, _reason}
+
+      conn =
+        Wait.until(fn ->
+          conn = Process.whereis(Module.concat([:shared_pool, Postgrex]))
+          assert is_pid(conn)
+
+          conn
+        end)
+
+      # Ensure newly started Postgrex connection can be used
+      assert {:ok, _events} = append_events_to_stream(:eventstore2, UUID.uuid4(), 1)
+
+      ref = Process.monitor(conn)
+
+      stop_supervised!(:eventstore2)
+
+      assert_receive {:DOWN, ^ref, :process, _object, _reason}
+    end
+
+    test "append and read events" do
+      stream_uuid = UUID.uuid4()
+
+      {:ok, events} = append_events_to_stream(:eventstore1, stream_uuid, 3)
+
+      assert_recorded_events(:eventstore1, stream_uuid, events)
+      refute_stream_exists(:eventstore2, stream_uuid)
+    end
+
+    test "subscribe to stream" do
+      stream_uuid = UUID.uuid4()
+
+      {:ok, subscription1} =
+        TestEventStore.subscribe_to_stream(stream_uuid, "subscriber1", self(), name: :eventstore1)
+
+      {:ok, subscription2} =
+        TestEventStore.subscribe_to_stream(stream_uuid, "subscriber2", self(), name: :eventstore2)
+
+      assert_receive {:subscribed, ^subscription1}
+      assert_receive {:subscribed, ^subscription2}
+
+      {:ok, _events} = append_events_to_stream(:eventstore1, stream_uuid, 3)
+
+      assert_receive {:events, _events}
+      refute_receive {:events, _events}
+    end
+  end
+
+  # Check that this is a `Postgrex` process by executing a database query.
+  defp assert_postgrex_connection(conn) do
+    assert {:ok, %Postgrex.Result{rows: [[1]]}} = Postgrex.query(conn, "SELECT 1;", [])
+  end
+
+  defp append_events_to_stream(event_store_name, stream_uuid, count, expected_version \\ 0) do
+    events = EventFactory.create_events(count, expected_version + 1)
+
+    :ok =
+      TestEventStore.append_to_stream(stream_uuid, expected_version, events,
+        name: event_store_name
+      )
+
+    {:ok, events}
+  end
+
+  defp assert_recorded_events(event_store_name, stream_uuid, expected_events) do
+    actual_events =
+      TestEventStore.stream_forward(stream_uuid, 0, name: event_store_name) |> Enum.to_list()
+
+    assert_events(expected_events, actual_events)
+  end
+
+  defp assert_events(expected_events, actual_events) do
+    assert length(expected_events) == length(actual_events)
+
+    for {expected, actual} <- Enum.zip(expected_events, actual_events) do
+      assert_event(expected, actual)
+    end
+  end
+
+  defp assert_event(expected_event, actual_event) do
+    assert expected_event.correlation_id == actual_event.correlation_id
+    assert expected_event.causation_id == actual_event.causation_id
+    assert expected_event.event_type == actual_event.event_type
+    assert expected_event.data == actual_event.data
+    assert expected_event.metadata == actual_event.metadata
+  end
+
+  defp refute_stream_exists(event_store_name, stream_uuid) do
+    assert {:error, :stream_not_found} ==
+             TestEventStore.stream_forward(stream_uuid, 0, name: event_store_name)
+  end
+end

--- a/test/support/observed_server.ex
+++ b/test/support/observed_server.ex
@@ -4,26 +4,37 @@ defmodule EventStore.ObservedServer do
   use GenServer
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, Keyword.take(opts, [:reply_to]), Keyword.take(opts, [:name]))
+    {start_opts, observer_opts} =
+      Keyword.split(opts, [:name, :timeout, :debug, :spawn_opt, :hibernate_after])
+
+    GenServer.start_link(__MODULE__, observer_opts, start_opts)
   end
 
-  def init(state) do
-    {:ok, state}
+  def init(opts) do
+    reply_to = Keyword.fetch!(opts, :reply_to)
+
+    send(reply_to, {:init, self()})
+
+    if Keyword.get(opts, :start_successfully, true) do
+      {:ok, reply_to}
+    else
+      {:error, :failed}
+    end
   end
 
-  def handle_call(:ping, _from, state) do
-    {:reply, {:ok, :pong}, state}
+  def handle_call(:ping, _from, reply_to) do
+    {:reply, {:ok, :pong}, reply_to}
   end
 
-  def handle_cast(:ping, [reply_to: reply_to] = state) do
+  def handle_cast(:ping, reply_to) do
     send(reply_to, :pong)
 
-    {:noreply, state}
+    {:noreply, reply_to}
   end
 
-  def handle_info(:ping, [reply_to: reply_to] = state) do
+  def handle_info(:ping, reply_to) do
     send(reply_to, :pong)
 
-    {:noreply, state}
+    {:noreply, reply_to}
   end
 end

--- a/test/support/process_helper.ex
+++ b/test/support/process_helper.ex
@@ -15,6 +15,6 @@ defmodule EventStore.ProcessHelper do
     Process.exit(pid, :shutdown)
 
     ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, _, _, _}, 1_000
+    assert_receive {:DOWN, ^ref, :process, _object, _reason}, 1_000
   end
 end


### PR DESCRIPTION
By default each event store will start its own `Postgrex` database connection pool. The size of the pool is configured with the `pool_size` config option.

When you have multiple event stores running you will also end up with multiple connection pools. If they are all connecting to the same physical Postgres database then it can be useful to share a single pool amongst all event stores. This pull request adds the `shared_connection_pool` config option to specify a name for the shared connection pool. Then you can configure the event stores you'd like to share the pool by using the same name.

This can be done in config:

```elixir
# config/config.exs
config :my_app, MyApp.EventStore1, shared_connection_pool: :shared_pool
config :my_app, MyApp.EventStore2, shared_connection_pool: :shared_pool
config :my_app, MyApp.EventStore3, shared_connection_pool: :shared_pool
```

Or when starting the event stores, such as via a `Supervisor`:

```elixir
Supervisor.start_link(
  [
    {MyApp.EventStore, name: :eventstore1, shared_connection_pool: :shared_pool},
    {MyApp.EventStore, name: :eventstore2, shared_connection_pool: :shared_pool},
    {MyApp.EventStore, name: :eventstore3, shared_connection_pool: :shared_pool}
  ],
  opts
)
```

Not specifying the `shared_connection_pool` config option indicates the event store will start its own connection pool. This is the existing behaviour. Not using this new shared pool feature should have no affect.

Closes #198.