### PR TITLE
v0.16.x

### DIFF
--- a/lib/event_store/notifications/supervisor.ex
+++ b/lib/event_store/notifications/supervisor.ex
@@ -26,7 +26,7 @@ defmodule EventStore.Notifications.Supervisor do
   supervised children, is kept running on a cluster of nodes.
   """
   def start_link(config) do
-    case Supervisor.start_link(__MODULE__, config, name: {:global, __MODULE__}) do
+    case Supervisor.start_link(__MODULE__, config, name: __MODULE__) do
       {:ok, pid} ->
         {:ok, pid}
 


### PR DESCRIPTION
Changes 

- Remove EventStore.Notifications.Supervisor registration as :global due to https://github.com/commanded/eventstore/issues/181