### PR TITLE
Feature/configure migration source

### DIFF
--- a/config/bench.exs
+++ b/config/bench.exs
@@ -19,6 +19,7 @@ default_config = [
 
 config :eventstore, TestEventStore, default_config
 config :eventstore, SchemaEventStore, default_config
+config :eventstore, MigrationSourceEventStore, default_config
 config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "eventstore_test_2")
 
 config :eventstore, event_stores: [TestEventStore]

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -27,5 +27,6 @@ config :eventstore,
        Keyword.put(default_config, :database, "eventstore_jsonb_test_2")
 
 config :eventstore, SchemaEventStore, default_config
+config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore]
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore,MigrationSourceEventStore]

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -29,4 +29,4 @@ config :eventstore,
 config :eventstore, SchemaEventStore, default_config
 config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore,MigrationSourceEventStore]
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/config/jsonb.exs
+++ b/config/jsonb.exs
@@ -29,4 +29,5 @@ config :eventstore,
 config :eventstore, SchemaEventStore, default_config
 config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]
+config :eventstore,
+  event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/config/migration.exs
+++ b/config/migration.exs
@@ -21,5 +21,6 @@ default_config = [
 config :eventstore, TestEventStore, default_config
 config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "eventstore_test_2")
 config :eventstore, SchemaEventStore, default_config
+config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore]
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/config/migration.exs
+++ b/config/migration.exs
@@ -23,4 +23,5 @@ config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "ev
 config :eventstore, SchemaEventStore, default_config
 config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]
+config :eventstore,
+  event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,5 +21,6 @@ default_config = [
 config :eventstore, TestEventStore, default_config
 config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "eventstore_test_2")
 config :eventstore, SchemaEventStore, default_config
+config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore]
+config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,4 +23,5 @@ config :eventstore, SecondEventStore, Keyword.put(default_config, :database, "ev
 config :eventstore, SchemaEventStore, default_config
 config :eventstore, MigrationSourceEventStore, default_config
 
-config :eventstore, event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]
+config :eventstore,
+  event_stores: [TestEventStore, SecondEventStore, SchemaEventStore, MigrationSourceEventStore]

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -120,6 +120,19 @@ You can use an existing PostgreSQL database with EventStore by running the follo
 $ mix event_store.init
 ```
 
+#### 👉 Heads up
+You might run into a naming colision. Ecto & EventStore are using the same name for the migration table. You have to options to avoid this issue:
+
+1. Change the Ecto migration table name with the `:migration_source` option. Please checkout the [Ecto migration documentation](https://hexdocs.pm/ecto_sql/Ecto.Migration.html) for more information
+2. You can do the same for EventStore. Change the name of the table name by providing a `:migration_source` option to your configuration
+
+```elixir
+config :your_app, Your.EventStore,
+  ...
+  migration_source: "event_source_migrations"
+```
+
+
 ## Reset an existing database
 
 To drop an existing EventStore database and recreate it you can run the following `mix` tasks:

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -57,7 +57,6 @@ defmodule EventStore.Config do
     end
   end
 
-
   @migration_source "schema_migrations"
 
   @doc """

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -57,6 +57,17 @@ defmodule EventStore.Config do
     end
   end
 
+
+  @migration_source "schema_migrations"
+
+  @doc """
+  Returns the configured migration_source value.
+  """
+  def get_migration_source(config) do
+    config
+    |> Keyword.get(:migration_source, @migration_source)
+  end
+
   @postgrex_connection_opts [
     :username,
     :password,

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -27,8 +27,8 @@ defmodule EventStore.Sql.Statements do
       create_subscriptions_table(),
       create_subscription_index(),
       create_snapshots_table(column_data_type),
-      create_schema_migrations_table(),
-      record_event_store_schema_version()
+      create_schema_migrations_table(config),
+      record_event_store_schema_version(config)
     ]
   end
 
@@ -266,9 +266,11 @@ defmodule EventStore.Sql.Statements do
   end
 
   # record execution of upgrade scripts
-  defp create_schema_migrations_table do
+  defp create_schema_migrations_table(config) do
+    migration_source = EventStore.Config.get_migration_source(config)
+
     """
-    CREATE TABLE schema_migrations
+    CREATE TABLE #{migration_source}
     (
         major_version int NOT NULL,
         minor_version int NOT NULL,
@@ -280,9 +282,11 @@ defmodule EventStore.Sql.Statements do
   end
 
   # record current event store schema version
-  defp record_event_store_schema_version do
+  defp record_event_store_schema_version(config) do
+    migration_source = EventStore.Config.get_migration_source(config)
+
     """
-    INSERT INTO schema_migrations (major_version, minor_version, patch_version)
+    INSERT INTO #{migration_source} (major_version, minor_version, patch_version)
     VALUES (1, 2, 0);
     """
   end

--- a/lib/event_store/storage/database.ex
+++ b/lib/event_store/storage/database.ex
@@ -16,6 +16,8 @@ defmodule EventStore.Storage.Database do
     end
   end
 
+  def execute_query(config, script), do: run_query(script, config)
+
   def dump(config, target_path) when is_binary(target_path) do
     dump(config, File.stream!(target_path))
   end

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -113,14 +113,14 @@ defmodule EventStore.Tasks.Migrate do
 
   defp query_schema_migrations(config) do
     config
-    |> run_query("SELECT major_version, minor_version, patch_version FROM schema_migrations")
+    |> run_query("SELECT major_version, minor_version, patch_version FROM $1", [ EventStore.Config.get_migration_source(config) ])
     |> handle_response()
   end
 
-  defp run_query(config, query) do
+  defp run_query(config, query, params) do
     {:ok, conn} = Postgrex.start_link(config)
 
-    reply = Postgrex.query!(conn, query, [])
+    reply = Postgrex.query!(conn, query, params)
 
     true = Process.unlink(conn)
     true = Process.exit(conn, :shutdown)

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -113,7 +113,9 @@ defmodule EventStore.Tasks.Migrate do
 
   defp query_schema_migrations(config) do
     config
-    |> run_query("SELECT major_version, minor_version, patch_version FROM $1", [ EventStore.Config.get_migration_source(config) ])
+    |> run_query("SELECT major_version, minor_version, patch_version FROM $1", [
+      EventStore.Config.get_migration_source(config)
+    ])
     |> handle_response()
   end
 

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -112,17 +112,17 @@ defmodule EventStore.Tasks.Migrate do
   end
 
   defp query_schema_migrations(config) do
+    migration_source = EventStore.Config.get_migration_source(config)
+
     config
-    |> run_query("SELECT major_version, minor_version, patch_version FROM $1", [
-      EventStore.Config.get_migration_source(config)
-    ])
+    |> run_query("SELECT major_version, minor_version, patch_version FROM #{migration_source}")
     |> handle_response()
   end
 
-  defp run_query(config, query, params) do
+  defp run_query(config, query) do
     {:ok, conn} = Postgrex.start_link(config)
 
-    reply = Postgrex.query!(conn, query, params)
+    reply = Postgrex.query!(conn, query, [])
 
     true = Process.unlink(conn)
     true = Process.exit(conn, :shutdown)

--- a/lib/event_store/tasks/migrations.ex
+++ b/lib/event_store/tasks/migrations.ex
@@ -88,9 +88,11 @@ defmodule EventStore.Tasks.Migrations do
   end
 
   defp query_schema_migrations(config) do
+    migration_source = Config.get_migration_source(config)
+
     config
     |> run_query(
-      "SELECT major_version, minor_version, patch_version, migrated_at FROM schema_migrations ORDER BY 1, 2, 3"
+      "SELECT major_version, minor_version, patch_version, migrated_at FROM #{migration_source} ORDER BY 1, 2, 3"
     )
     |> handle_response()
   end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -5,6 +5,7 @@ defmodule EventStore.ConfigTest do
 
   test "parse keys" do
     config = [
+      migration_source: "my_new_migration_source",
       username: "postgres",
       hostname: "localhost",
       database: "eventstore_test",
@@ -22,6 +23,7 @@ defmodule EventStore.ConfigTest do
                database: "eventstore_test",
                hostname: "localhost",
                username: "postgres",
+               migration_source: "my_new_migration_source",
                pool: EventStore.Config.get_pool()
              ]
   end

--- a/test/migration_source_test.exs
+++ b/test/migration_source_test.exs
@@ -1,0 +1,16 @@
+defmodule MigrationSourceTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias EventStore.Storage.Database
+
+
+  setup_all do
+    config = MigrationSourceEventStore.config()
+
+    [config: config]
+  end
+
+  # TODO: have to look into how we should test this
+end

--- a/test/migration_source_test.exs
+++ b/test/migration_source_test.exs
@@ -1,16 +1,28 @@
-defmodule MigrationSourceTest do
+defmodule EventStore.Storage.MigrationSourceTest do
   use ExUnit.Case
 
-  import ExUnit.CaptureIO
-
+  alias EventStore.Config
   alias EventStore.Storage.Database
 
-
   setup_all do
-    config = MigrationSourceEventStore.config()
+    config =  MigrationSourceEventStore.config()
 
     [config: config]
   end
 
-  # TODO: have to look into how we should test this
+  test "test migration source has the correct name and retuns a value", %{config: config} do
+    # construct a query
+    migration_source = Config.get_migration_source(config)
+    schema = Keyword.get(config, :schema)
+    script = "select major_version, minor_version, patch_version from #{schema}.#{migration_source}"
+
+    # get the result from the database
+    {:ok, result} = Database.execute_query(config, script)
+    [major, minor, patch] = List.first(result.rows)
+
+    # this verifies that we actually have values for major, minor & patch
+    assert major >= 0
+    assert minor >= 0
+    assert patch >= 0
+  end
 end

--- a/test/migration_source_test.exs
+++ b/test/migration_source_test.exs
@@ -1,4 +1,4 @@
-defmodule EventStore.Storage.MigrationSourceTest do
+defmodule MigrationSourceTest do
   use ExUnit.Case
 
   alias EventStore.Config

--- a/test/migration_source_test.exs
+++ b/test/migration_source_test.exs
@@ -5,7 +5,7 @@ defmodule MigrationSourceTest do
   alias EventStore.Storage.Database
 
   setup_all do
-    config =  MigrationSourceEventStore.config()
+    config = MigrationSourceEventStore.config()
 
     [config: config]
   end
@@ -14,7 +14,9 @@ defmodule MigrationSourceTest do
     # construct a query
     migration_source = Config.get_migration_source(config)
     schema = Keyword.get(config, :schema)
-    script = "select major_version, minor_version, patch_version from #{schema}.#{migration_source}"
+
+    script =
+      "select major_version, minor_version, patch_version from #{schema}.#{migration_source}"
 
     # get the result from the database
     {:ok, result} = Database.execute_query(config, script)

--- a/test/support/migration_source.ex
+++ b/test/support/migration_source.ex
@@ -1,0 +1,3 @@
+defmodule MigrationSourceEventStore do
+  use EventStore, otp_app: :eventstore, migration_source: "example_migration_source", schema: "migration_source"
+end

--- a/test/support/migration_source.ex
+++ b/test/support/migration_source.ex
@@ -1,3 +1,6 @@
 defmodule MigrationSourceEventStore do
-  use EventStore, otp_app: :eventstore, migration_source: "example_migration_source", schema: "migration_source"
+  use EventStore,
+    otp_app: :eventstore,
+    migration_source: "example_migration_source",
+    schema: "migration_source"
 end


### PR DESCRIPTION
This allows users to change the `migration_source` table name. Keeping the same naming convention as Ecto seemed appropriate :)

- Updated Database.ex and added a new `execute_query` method which returns the result
- Added a new Test case which verifies that querying the database with a `migration_source` set actually works and returns some values
- Updated the `Using an existing database` section of the documentation
