### PR TITLE
Adds an option to supply a db connection #176

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -410,7 +410,7 @@ defmodule EventStore do
       defp parse_opts(opts) do
         name = name(opts)
         config = Config.lookup(name)
-        conn = Keyword.fetch!(config, :conn)
+        conn = Keyword.get(opts, :conn) || Keyword.fetch!(config, :conn)
         timeout = timeout(opts, config)
 
         {conn, Keyword.put(config, :timeout, timeout)}


### PR DESCRIPTION
so we can wrap `append_to_stream`/`link_to_stream` operations in a transaction
Tackles #176 