### PR TITLE
Allow an `event_id` to be provided when appending events #227

### DIFF
--- a/lib/event_store/event_data.ex
+++ b/lib/event_store/event_data.ex
@@ -23,6 +23,23 @@ defmodule EventStore.EventData do
           metadata: term | nil
         }
 
+  def new(event_id, %event_type{} = event, metadata)
+      when not is_nil(event_id) and not is_nil(metadata) do
+    {:ok, _} = UUID.info(event_id)
+
+    %__MODULE__{
+      event_id: event_id,
+      data: event,
+      event_type: Atom.to_string(event_type),
+      metadata: metadata
+    }
+  end
+
+  def new(event, metadata) do
+    event_id = UUID.uuid4()
+    new(event_id, event, metadata)
+  end
+
   def fetch(map, key) when is_map(map) do
     Map.fetch(map, key)
   end

--- a/lib/event_store/event_data.ex
+++ b/lib/event_store/event_data.ex
@@ -2,6 +2,7 @@ defmodule EventStore.EventData do
   @moduledoc """
   EventData contains the data for a single event before being persisted to storage
   """
+  alias EventStore.RecordedEvent
 
   defstruct [
     :event_id,
@@ -38,6 +39,17 @@ defmodule EventStore.EventData do
   def new(event, metadata) do
     event_id = UUID.uuid4()
     new(event_id, event, metadata)
+  end
+
+  def caused_by(%__MODULE__{} = event_data, %RecordedEvent{
+        event_id: event_id,
+        correlation_id: correlation_id
+      }) do
+    %__MODULE__{
+      event_data
+      | causation_id: event_id,
+        correlation_id: correlation_id || event_id
+    }
   end
 
   def fetch(map, key) when is_map(map) do

--- a/test/append_to_stream_test.exs
+++ b/test/append_to_stream_test.exs
@@ -173,6 +173,25 @@ defmodule EventStore.AppendToStreamTest do
              Enum.to_list(1..8_001)
   end
 
+  test "should use given event id if provided" do
+    events = [
+      event_1 = EventFactory.create_event(UUID.uuid4()),
+      event_2 = EventFactory.create_event(UUID.uuid4())
+    ]
+
+    assert event_1.event_id
+    assert event_2.event_id
+
+    stream_uuid = UUID.uuid4()
+    assert :ok = EventStore.append_to_stream(stream_uuid, :any_version, events)
+
+    assert {:ok, [appended_event_1, appended_event_2]} =
+             EventStore.read_stream_forward(stream_uuid)
+
+    assert event_1.event_id == appended_event_1.event_id
+    assert event_2.event_id == appended_event_2.event_id
+  end
+
   defp append_events_to_stream(_context) do
     stream_uuid = UUID.uuid4()
     events = EventFactory.create_events(3)

--- a/test/event_data_test.exs
+++ b/test/event_data_test.exs
@@ -1,0 +1,45 @@
+defmodule EventStore.EventEventDataTest do
+  use EventStore.StorageCase
+
+  alias EventStore.EventData
+  alias EventStore.EventFactory.Event
+
+  describe "new/3" do
+    test "sets event_id, data and metadata" do
+      event_id = UUID.uuid4()
+      event = Event.new(5)
+      metadata = %{foo: "bar"}
+
+      assert event_data = EventData.new(event_id, event, metadata)
+      assert event_data.event_id == event_id
+      assert event_data.data == event
+      assert event_data.event_type == "Elixir.EventStore.EventFactory.Event"
+      assert event_data.metadata == metadata
+    end
+
+    test "does not allow invalid event_id to be set" do
+      event_id = "not an uuid"
+      event = Event.new(5)
+      metadata = %{foo: "bar"}
+
+      assert_raise MatchError, fn ->
+        EventData.new(event_id, event, metadata)
+      end
+    end
+
+    test "does generate an event_id if not provided" do
+      event = Event.new(5)
+      metadata = %{foo: "bar"}
+
+      assert event_data = EventData.new(event, metadata)
+
+      assert event_id = event_data.event_id
+      assert {:ok, valid_uuid_info} = UUID.info(event_id)
+      assert valid_uuid_info[:version] == 4
+
+      assert event_data.data == event
+      assert event_data.event_type == "Elixir.EventStore.EventFactory.Event"
+      assert event_data.metadata == metadata
+    end
+  end
+end

--- a/test/event_data_test.exs
+++ b/test/event_data_test.exs
@@ -2,7 +2,9 @@ defmodule EventStore.EventEventDataTest do
   use EventStore.StorageCase
 
   alias EventStore.EventData
-  alias EventStore.EventFactory.Event
+  alias EventStore.EventFactory
+  alias EventFactory.Event
+  alias EventStore.RecordedEvent
 
   describe "new/3" do
     test "sets event_id, data and metadata" do
@@ -40,6 +42,32 @@ defmodule EventStore.EventEventDataTest do
       assert event_data.data == event
       assert event_data.event_type == "Elixir.EventStore.EventFactory.Event"
       assert event_data.metadata == metadata
+    end
+  end
+
+  describe "caused_by/2" do
+    test "should add causation and correlation ids" do
+      [%RecordedEvent{} = event_causing_change] =
+        EventFactory.create_recorded_events(_how_many = 1, _stream_id = UUID.uuid4())
+
+      event_data = EventData.new(UUID.uuid4(), Event.new(5), %{foo: "bar"})
+      event_data = event_data |> EventData.caused_by(event_causing_change)
+
+      assert event_data.causation_id == event_causing_change.event_id
+      assert event_data.correlation_id == event_causing_change.correlation_id
+    end
+
+    test "should set correlation_id to event_id if the correlation_id of the event causing change is not provided" do
+      [%RecordedEvent{} = event_causing_change] =
+        EventFactory.create_recorded_events(_how_many = 1, _stream_id = UUID.uuid4())
+
+      event_causing_change = %{event_causing_change | correlation_id: nil}
+
+      event_data = EventData.new(UUID.uuid4(), Event.new(5), %{foo: "bar"})
+      event_data = event_data |> EventData.caused_by(event_causing_change)
+
+      assert event_data.causation_id == event_causing_change.event_id
+      assert event_data.correlation_id == event_causing_change.event_id
     end
   end
 end

--- a/test/support/event_factory.ex
+++ b/test/support/event_factory.ex
@@ -7,6 +7,12 @@ defmodule EventStore.EventFactory do
   defmodule Event do
     @derive Jason.Encoder
     defstruct [:event]
+
+    def new(event_content) do
+      %__MODULE__{
+        event: event_content
+      }
+    end
   end
 
   def create_event(event_id, number \\ 1) do


### PR DESCRIPTION
#227
In fact, I had nothing to do to implement this feature. If an `event_id` is provided, [this line](https://github.com/commanded/eventstore/blob/master/lib/event_store/streams/stream.ex#L144) ensures that this id is used actually. I just added a test, so it stays so.
Additionally, I added some convenience ("constructor") functions for `EventStore.EventData`. They can be used to build correct EventData structs. I do not know if you like the function names though.

Pay special attention to the `caused_by/2` function. It sets `causation_id`/`correlation_id` the same way Gregg Young uses it:
> Let’s say every message has 3 ids. 1 is its id. Another is correlation, the last is causation. If you are responding to a message, you copy its correlation id as your correlation id, its message id is your causation id. This allows you to see an entire conversation (correlation id) or to see what causes what (causation id).

So, if you do not like my additions, you could cherry-pick the test only...