### PR TITLE
Add `:configure` to postgrex connection options.

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -69,6 +69,7 @@ defmodule EventStore.Config do
     :password,
     :database,
     :hostname,
+    :configure,
     :port,
     :types,
     :socket,


### PR DESCRIPTION
This is useful for specifying dynamic connection config per connection.