### PR TITLE
Read stream and stream events backward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next release
+
+- Read stream and stream events backward ([#234](https://github.com/commanded/eventstore/pull/234)).
+
 ## v1.2.1
 
 - Allow optional `event_id` to be included in `EventStore.EventData` struct ([#229](https://github.com/commanded/eventstore/pull/229)).

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -26,7 +26,8 @@ defmodule EventStore.Sql.Statements do
         {:query_subscription, [:schema]},
         {:query_stream_info, [:schema]},
         {:query_snapshot, [:schema]},
-        {:query_stream_events, [:schema]}
+        {:query_stream_events_backward, [:schema]},
+        {:query_stream_events_forward, [:schema]}
       ] do
     file = Path.expand("statements/#{fun}.sql.eex", __DIR__)
 

--- a/lib/event_store/sql/statements/query_stream_events_backward.sql.eex
+++ b/lib/event_store/sql/statements/query_stream_events_backward.sql.eex
@@ -1,0 +1,19 @@
+SELECT
+  se.stream_version,
+  e.event_id,
+  s.stream_uuid,
+  se.original_stream_version,
+  e.event_type,
+  e.correlation_id,
+  e.causation_id,
+  e.data,
+  e.metadata,
+  e.created_at
+FROM <%= schema %>.stream_events se
+INNER JOIN <%= schema %>.streams s ON s.stream_id = se.original_stream_id
+INNER JOIN <%= schema %>.events e ON se.event_id = e.event_id
+WHERE
+  se.stream_id = $1 AND (se.stream_version <= $2 OR $2 = -1)
+ORDER BY
+  se.stream_version DESC
+LIMIT $3;

--- a/lib/event_store/sql/statements/query_stream_events_forward.sql.eex
+++ b/lib/event_store/sql/statements/query_stream_events_forward.sql.eex
@@ -12,6 +12,8 @@ SELECT
 FROM <%= schema %>.stream_events se
 INNER JOIN <%= schema %>.streams s ON s.stream_id = se.original_stream_id
 INNER JOIN <%= schema %>.events e ON se.event_id = e.event_id
-WHERE se.stream_id = $1 AND se.stream_version >= $2
-ORDER BY se.stream_version ASC
+WHERE
+  se.stream_id = $1 AND se.stream_version >= $2
+ORDER BY
+  se.stream_version ASC
 LIMIT $3;

--- a/lib/event_store/storage.ex
+++ b/lib/event_store/storage.ex
@@ -35,6 +35,14 @@ defmodule EventStore.Storage do
     as: :read_forward
 
   @doc """
+  Read events for the given stream backward from the starting version, use -1
+  for all events for the stream.
+  """
+  defdelegate read_stream_backward(conn, stream_id, start_version, count, opts),
+    to: Reader,
+    as: :read_backward
+
+  @doc """
   Get the id and version of the stream with the given `stream_uuid`.
   """
   defdelegate stream_info(conn, stream_uuid, opts), to: QueryStreamInfo, as: :execute

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -44,9 +44,21 @@ defmodule EventStore.Streams.Stream do
     end
   end
 
+  def read_stream_backward(conn, stream_uuid, start_version, count, opts) do
+    with {:ok, stream} <- stream_info(conn, stream_uuid, :stream_exists, opts) do
+      read_storage_backward(conn, stream, start_version, count, opts)
+    end
+  end
+
   def stream_forward(conn, stream_uuid, start_version, opts) do
     with {:ok, stream} <- stream_info(conn, stream_uuid, :stream_exists, opts) do
       stream_storage_forward(conn, stream, start_version, opts)
+    end
+  end
+
+  def stream_backward(conn, stream_uuid, start_version, opts) do
+    with {:ok, stream} <- stream_info(conn, stream_uuid, :stream_exists, opts) do
+      stream_storage_backward(conn, stream, start_version, opts)
     end
   end
 
@@ -177,17 +189,28 @@ defmodule EventStore.Streams.Stream do
 
     {serializer, opts} = Keyword.pop(opts, :serializer)
 
-    case Storage.read_stream_forward(conn, stream_id, start_version, count, opts) do
-      {:ok, recorded_events} ->
-        deserialized_events = deserialize_recorded_events(recorded_events, serializer)
+    with {:ok, recorded_events} <-
+           Storage.read_stream_forward(conn, stream_id, start_version, count, opts) do
+      deserialized_events = deserialize_recorded_events(recorded_events, serializer)
 
-        {:ok, deserialized_events}
-
-      {:error, _error} = reply ->
-        reply
+      {:ok, deserialized_events}
     end
   end
 
+  defp read_storage_backward(conn, %StreamInfo{} = stream, start_version, count, opts) do
+    %StreamInfo{stream_id: stream_id} = stream
+
+    {serializer, opts} = Keyword.pop(opts, :serializer)
+
+    with {:ok, recorded_events} <-
+           Storage.read_stream_backward(conn, stream_id, start_version, count, opts) do
+      deserialized_events = deserialize_recorded_events(recorded_events, serializer)
+
+      {:ok, deserialized_events}
+    end
+  end
+
+  # Stream forwards from the first event in the stream.
   defp stream_storage_forward(conn, stream, 0, opts),
     do: stream_storage_forward(conn, stream, 1, opts)
 
@@ -202,7 +225,33 @@ defmodule EventStore.Streams.Stream do
           {:ok, events} -> {events, next_version + length(events)}
         end
       end,
-      fn _ -> :ok end
+      fn _next_version -> :ok end
+    )
+  end
+
+  # Stream backwards from the last event in the stream.
+  defp stream_storage_backward(conn, stream, -1, opts) do
+    %StreamInfo{stream_version: stream_version} = stream
+
+    stream_storage_backward(conn, stream, stream_version, opts)
+  end
+
+  defp stream_storage_backward(conn, stream, start_version, opts) do
+    read_batch_size = Keyword.fetch!(opts, :read_batch_size)
+
+    Elixir.Stream.resource(
+      fn -> start_version end,
+      fn
+        next_version when next_version <= 0 ->
+          {:halt, 0}
+
+        next_version ->
+          case read_storage_backward(conn, stream, next_version, read_batch_size, opts) do
+            {:ok, []} -> {:halt, next_version}
+            {:ok, events} -> {events, next_version - length(events)}
+          end
+      end,
+      fn _next_version -> :ok end
     )
   end
 

--- a/test/streams/all_stream_test.exs
+++ b/test/streams/all_stream_test.exs
@@ -33,7 +33,9 @@ defmodule EventStore.Streams.AllStreamTest do
     test "should stream events from all streams using single event batch size", %{
       conn: conn,
       schema: schema,
-      serializer: serializer
+      serializer: serializer,
+      stream1_uuid: stream1_uuid,
+      stream2_uuid: stream2_uuid
     } do
       read_events =
         Stream.stream_forward(conn, @all_stream, 0,
@@ -44,6 +46,17 @@ defmodule EventStore.Streams.AllStreamTest do
         |> Enum.to_list()
 
       assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [1, 2, 3, 4, 5, 6]
+      assert Enum.map(read_events, & &1.stream_version) == [1, 2, 3, 1, 2, 3]
+
+      assert Enum.map(read_events, & &1.stream_uuid) == [
+               stream1_uuid,
+               stream1_uuid,
+               stream1_uuid,
+               stream2_uuid,
+               stream2_uuid,
+               stream2_uuid
+             ]
     end
 
     test "should stream events from all streams using two event batch size", %{
@@ -60,9 +73,11 @@ defmodule EventStore.Streams.AllStreamTest do
         |> Enum.to_list()
 
       assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [1, 2, 3, 4, 5, 6]
+      assert Enum.map(read_events, & &1.stream_version) == [1, 2, 3, 1, 2, 3]
     end
 
-    test "should stream events from all streams uisng large batch size", %{
+    test "should stream events from all streams using large batch size", %{
       conn: conn,
       schema: schema,
       serializer: serializer
@@ -76,6 +91,95 @@ defmodule EventStore.Streams.AllStreamTest do
         |> Enum.to_list()
 
       assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [1, 2, 3, 4, 5, 6]
+      assert Enum.map(read_events, & &1.stream_version) == [1, 2, 3, 1, 2, 3]
+    end
+  end
+
+  describe "stream backward" do
+    setup [:append_events_to_streams]
+
+    test "should stream events from all streams using single event batch size", %{
+      conn: conn,
+      schema: schema,
+      serializer: serializer,
+      stream1_uuid: stream1_uuid,
+      stream2_uuid: stream2_uuid
+    } do
+      read_events =
+        Stream.stream_backward(conn, @all_stream, -1,
+          read_batch_size: 1,
+          schema: schema,
+          serializer: serializer
+        )
+        |> Enum.to_list()
+
+      assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [6, 5, 4, 3, 2, 1]
+      assert Enum.map(read_events, & &1.stream_version) == [3, 2, 1, 3, 2, 1]
+
+      assert Enum.map(read_events, & &1.stream_uuid) == [
+               stream2_uuid,
+               stream2_uuid,
+               stream2_uuid,
+               stream1_uuid,
+               stream1_uuid,
+               stream1_uuid
+             ]
+    end
+
+    test "should stream events from all streams using two event batch size", %{
+      conn: conn,
+      schema: schema,
+      serializer: serializer
+    } do
+      read_events =
+        Stream.stream_backward(conn, @all_stream, -1,
+          read_batch_size: 2,
+          schema: schema,
+          serializer: serializer
+        )
+        |> Enum.to_list()
+
+      assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [6, 5, 4, 3, 2, 1]
+      assert Enum.map(read_events, & &1.stream_version) == [3, 2, 1, 3, 2, 1]
+    end
+
+    test "should stream events from all streams using large batch size", %{
+      conn: conn,
+      schema: schema,
+      serializer: serializer
+    } do
+      read_events =
+        Stream.stream_backward(conn, @all_stream, -1,
+          read_batch_size: 1_000,
+          schema: schema,
+          serializer: serializer
+        )
+        |> Enum.to_list()
+
+      assert length(read_events) == 6
+      assert Enum.map(read_events, & &1.event_number) == [6, 5, 4, 3, 2, 1]
+      assert Enum.map(read_events, & &1.stream_version) == [3, 2, 1, 3, 2, 1]
+    end
+
+    test "should stream events from all streams using offset", %{
+      conn: conn,
+      schema: schema,
+      serializer: serializer
+    } do
+      read_events =
+        Stream.stream_backward(conn, @all_stream, 3,
+          read_batch_size: 1_000,
+          schema: schema,
+          serializer: serializer
+        )
+        |> Enum.to_list()
+
+      assert length(read_events) == 3
+      assert Enum.map(read_events, & &1.event_number) == [3, 2, 1]
+      assert Enum.map(read_events, & &1.stream_version) == [3, 2, 1]
     end
   end
 


### PR DESCRIPTION
Adds the following event store functions to read streams backwards (reverse chronological order).

* `EventStore.read_stream_backward/4`
* `EventStore.read_all_streams_backward/3`
* `EventStore.stream_backward/3`
* `EventStore.stream_all_backward/2`

