### PR TITLE
Remove unsupported call to Init.exec/3 into a call to Init.exec/3

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -155,7 +155,7 @@ defmodule MyApp.ReleaseTasks do
     config = MyApp.EventStore.config()
 
     :ok = EventStore.Tasks.Create.exec(config, [])
-    :ok = EventStore.Tasks.Init.exec(MyApp.EventStore, config, [])
+    :ok = EventStore.Tasks.Init.exec(config, [])
   end
 end
 ```


### PR DESCRIPTION
Looks like this changed recently. Not sure if this is correct though.