### PR TITLE
Use runtime configuration in Mix tasks

### DIFF
--- a/lib/mix/event_store.ex
+++ b/lib/mix/event_store.ex
@@ -63,10 +63,12 @@ defmodule Mix.EventStore do
   """
   @spec ensure_event_store!(module, list) :: EventStore.t()
   def ensure_event_store!(event_store, args) do
-    Mix.Task.run("loadpaths", args)
-
-    unless "--no-compile" in args do
-      Mix.Task.run("compile", args)
+    # TODO: Use only app.config when we depend on Elixir v1.11+.
+    if Code.ensure_loaded?(Mix.Tasks.App.Config) do
+      Mix.Task.run("app.config", args)
+    else
+      Mix.Task.run("loadpaths", args)
+      "--no-compile" not in args && Mix.Task.run("compile", args)
     end
 
     case Code.ensure_compiled(event_store) do


### PR DESCRIPTION
When Eventstore configuration is defined in `config/runtime.exs` (for example to load environment variables), the Mix task helper `ensure_event_store!/2` needs to look at the runtime configuration as well.

The code change reflects [what is being done by Ecto in `ensure_repo/2`](https://github.com/elixir-ecto/ecto/blob/master/lib/mix/ecto.ex#L66).