### PR TITLE
Fix bug with catch-up all streams subscription where the checkpoint is not committed for hard deleted streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Improve performance of appending events under normal and degraded network conditions ([#230](https://github.com/commanded/eventstore/pull/230)).
 - Subscription checkpoint tuning ([#237](https://github.com/commanded/eventstore/pull/237)).
 
+## Bug fixes
+
+- Fix bug with catch-up all streams subscription where the checkpoint is not committed for hard deleted streams ([#238](https://github.com/commanded/eventstore/pull/238)).
+
 ## v1.2.3
 
 - Add `:configure` to postgrex connection options ([#233](https://github.com/commanded/eventstore/pull/233)).

--- a/test/subscriptions/subscription_acknowledgement_test.exs
+++ b/test/subscriptions/subscription_acknowledgement_test.exs
@@ -60,7 +60,7 @@ defmodule EventStore.Subscriptions.SubscriptionAcknowledgementTest do
 
     test "should checkpoint after inactivity", %{conn: conn} do
       {:ok, subscription} =
-        subscribe_to_all_streams(buffer_size: 3, checkpoint_after: 10, checkpoint_threshold: 100)
+        subscribe_to_all_streams(buffer_size: 3, checkpoint_after: 25, checkpoint_threshold: 100)
 
       :ok = append_to_stream("stream1", 3)
       :ok = receive_and_ack(subscription, "stream1", [1, 2, 3])

--- a/test/subscriptions/subscription_catch_up_test.exs
+++ b/test/subscriptions/subscription_catch_up_test.exs
@@ -7,6 +7,8 @@ defmodule EventStore.Subscriptions.SubscriptionCatchUpTest do
 
   describe "catch-up subscription" do
     test "should receive all existing events" do
+      restart_event_store_with_config(enable_hard_deletes: false)
+
       subscription_name = UUID.uuid4()
 
       stream1_uuid = UUID.uuid4()
@@ -40,6 +42,90 @@ defmodule EventStore.Subscriptions.SubscriptionCatchUpTest do
 
       refute_receive {:events, _events}
     end
+
+    test "should receive events from soft deleted streams" do
+      restart_event_store_with_config(enable_hard_deletes: false)
+
+      subscription_name = UUID.uuid4()
+
+      stream1_uuid = UUID.uuid4()
+      stream2_uuid = UUID.uuid4()
+      stream3_uuid = UUID.uuid4()
+      stream4_uuid = UUID.uuid4()
+
+      append_to_stream(stream1_uuid, 10)
+      append_to_stream(stream2_uuid, 10)
+      append_to_stream(stream3_uuid, 10)
+      append_to_stream(stream4_uuid, 10)
+
+      :ok = EventStore.delete_stream(stream2_uuid, 10, :soft)
+
+      {:ok, subscription} = subscribe_to_all_streams(subscription_name, self(), buffer_size: 10)
+
+      append_to_stream(stream1_uuid, 10, 10)
+
+      receive_and_ack(subscription, stream1_uuid, 1)
+      receive_and_ack(subscription, stream2_uuid, 11)
+      receive_and_ack(subscription, stream3_uuid, 21)
+      receive_and_ack(subscription, stream4_uuid, 31)
+
+      append_to_stream(stream1_uuid, 10, 20)
+
+      receive_and_ack(subscription, stream1_uuid, 41)
+      receive_and_ack(subscription, stream1_uuid, 51)
+
+      refute_receive {:events, _events}
+
+      append_to_stream(stream1_uuid, 10, 30)
+      receive_and_ack(subscription, stream1_uuid, 61)
+
+      refute_receive {:events, _events}
+    end
+
+    test "should skip events from hard deleted streams" do
+      restart_event_store_with_config(enable_hard_deletes: true)
+
+      subscription_name = UUID.uuid4()
+
+      stream1_uuid = UUID.uuid4()
+      stream2_uuid = UUID.uuid4()
+      stream3_uuid = UUID.uuid4()
+      stream4_uuid = UUID.uuid4()
+
+      append_to_stream(stream1_uuid, 10)
+      append_to_stream(stream2_uuid, 10)
+      append_to_stream(stream3_uuid, 10)
+      append_to_stream(stream4_uuid, 10)
+
+      :ok = EventStore.delete_stream(stream2_uuid, 10, :hard)
+
+      {:ok, subscription} = subscribe_to_all_streams(subscription_name, self(), buffer_size: 10)
+
+      append_to_stream(stream1_uuid, 10, 10)
+
+      receive_and_ack(subscription, stream1_uuid, 1)
+      receive_and_ack(subscription, stream3_uuid, 21)
+      receive_and_ack(subscription, stream4_uuid, 31)
+
+      append_to_stream(stream1_uuid, 10, 20)
+
+      receive_and_ack(subscription, stream1_uuid, 41)
+      receive_and_ack(subscription, stream1_uuid, 51)
+
+      refute_receive {:events, _events}
+
+      append_to_stream(stream1_uuid, 10, 30)
+
+      receive_and_ack(subscription, stream1_uuid, 61)
+
+      refute_receive {:events, _events}
+    end
+  end
+
+  defp assert_last_ack(subscription, expected_ack) do
+    last_seen = Subscription.last_seen(subscription)
+
+    assert last_seen == expected_ack
   end
 
   defp append_to_stream(stream_uuid, event_count, expected_version \\ 0) do
@@ -71,5 +157,14 @@ defmodule EventStore.Subscriptions.SubscriptionCatchUpTest do
     end)
 
     :ok = Subscription.ack(subscription, received_events)
+
+    assert_last_ack(subscription, expected_intial_event_number + 9)
+  end
+
+  defp restart_event_store_with_config(config) do
+    stop_supervised!(TestEventStore)
+    start_supervised!({TestEventStore, config})
+
+    :ok
   end
 end


### PR DESCRIPTION
Track in-flight events sent to subscribers to ensure that the last seen checkpoint is committed for a subscription. The acknowledgements are correlated with the events sent to the subscriber. 

This pull request ensures that a catch-up subscription to all streams will correctly commit the last seen checkpoint even when a stream has been hard deleted which causes gaps in the sequence of event numbers. Previously it was assumed there would be no gaps in the event number sequence so the checkpoint could be determined as "last checkpoint + 1" (1, 2, 3, 4, etc.). However this is not the case when a stream has been hard deleted since its events will also be removed leaving gaps in the "all stream" event number sequence (e.g. 1, 2, 9, 10, 15, 16). 

Without this change a catch-up subscription to a stream containing events from another stream that has been hard deleted will not persist the last seen checkpoint once it reaches the position of a hard deleted event. Therefore whenever the subscription restarts it will replay all events from the checkpoint, this will be the position of the first hard deleted event.