### PR TITLE
Update .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.12.2-otp-23
-erlang 23.3.4.4
+erlang 23.3.4


### PR DESCRIPTION
Similar typo as was found in commanded/commanded which prevented a standalone install.  (ElixirLS complaining about not being able to find elixir was how I found this.)