### PR TITLE
Add test for jsonb serializer and handle lists and unknown atoms

### DIFF
--- a/lib/event_store/jsonb_serializer.ex
+++ b/lib/event_store/jsonb_serializer.ex
@@ -30,9 +30,11 @@ defmodule EventStore.JsonbSerializer do
     struct(type, keys_to_atoms(term))
   end
 
+  defp keys_to_atoms(list) when is_list(list), do: list |> Enum.map(&keys_to_atoms/1)
+
   defp keys_to_atoms(map) when is_map(map) do
     for {key, value} <- map, into: %{} do
-      {String.to_existing_atom(key), keys_to_atoms(value)}
+      {String.to_atom(key), keys_to_atoms(value)}
     end
   end
 

--- a/test/jsonb_serializer_test.exs
+++ b/test/jsonb_serializer_test.exs
@@ -1,0 +1,44 @@
+defmodule EventStore.JsonbSerializerTest do
+  use ExUnit.Case
+  alias EventStore.JsonbSerializer
+
+  defmodule TestStruct do
+    defstruct [:one, :two]
+  end
+
+  test "Converts first level atoms to strings" do
+    data = %TestStruct{one: 1, two: %{three: 3, four: %{five: 5}}}
+
+    serialized = %{"one" => 1, "two" => %{four: %{five: 5}, three: 3}}
+
+    assert JsonbSerializer.serialize(data) == serialized
+  end
+
+  test "Convert all string keys to atom in struct with list and map" do
+    data = %{
+      "one" => 1,
+      "two" => %{
+        "three" => 3,
+        "four" => [
+          %{"five" => 5}
+        ]
+      }
+    }
+
+    struct_value =
+      JsonbSerializer.deserialize(data,
+        type: "Elixir.EventStore.JsonbSerializerTest.TestStruct"
+      )
+
+    assert struct_value == %TestStruct{
+             one: 1,
+             two: %{
+               three: 3,
+               four: [
+                 %{five: 5}
+               ]
+             }
+           }
+  end
+
+end


### PR DESCRIPTION
I had a problem when using events that had nested data

1. The original uses String.to_existing_atom/1 which crashes when we try to convert a string to atom that is not already on the erlang vm
2. The original deserialiser does not convert maps in lists to atoms, which we need for our events

This change fixes both of those issues, although I solved this locally with my own serialiser, I guessed other people might run into the same issue. Also because of this my tests were passing with in memory adaptor but failing with postgres, this change aligns both when using nested event data