### PR TITLE
Avoid Dialyzer old PLT file error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['23.3']
+        otp: ['23.3', '24.2']
         elixir: ['1.13.1']
 
     services:
@@ -29,16 +29,17 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Elixir
+      id: beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{matrix.elixir}}
-        otp-version: ${{matrix.otp}}
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
 
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:
         path: deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
 
     - name: Install dependencies
@@ -63,7 +64,7 @@ jobs:
       id: plt-cache
       with:
         path: priv/plts
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-plts-${{ hashFiles('**/mix.lock') }}
 
     - name: Create Dialyzer PLTs
       if: steps.plt-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR intends to avoid errors like `:dialyzer.run error: Old PLT file`. More on https://github.com/commanded/commanded/pull/473