### PR TITLE
Add option to use Eventstore with PGBouncer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ MIT License
   - [Using Postgres schemas](guides/Getting%20Started.md#using-postgres-schemas)
   - [Event data and metadata data type](guides/Getting%20Started.md#event-data-and-metadata-data-type)
     - [Using the `jsonb` data type](guides/Getting%20Started.md#using-the-jsonb-data-type)
+  - [Using with Pgbouncer](guides/Getting%20Started.md#using-with-pg-bouncer)
 - [Using the EventStore](guides/Usage.md)
   - [Writing to a stream](guides/Usage.md#writing-to-a-stream)
     - [Appending events to an existing stream](guides/Usage.md#appending-events-to-an-existing-stream)

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -37,7 +37,7 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
 
       # OR use a URL to connect instead
       config :my_app, MyApp.EventStore,
-        serializer: EventStore.JsonSerializer,          
+        serializer: EventStore.JsonSerializer,
         url: "postgres://postgres:postgres@localhost/eventstore"
       ```
 
@@ -228,3 +228,16 @@ end
 ```
 
 These settings must be configured *before* creating the EventStore database. It's not possible to migrate between `bytea` and `jsonb` data types once you've created the database. This must be decided in advance.
+
+## Using with Pgbouncer
+
+Eventstore uses `LISTEN/NOTIFY` and `pg_advisory_locks` Postgres capabalities. Unfortunately, they are not compatible with PGBouncer running in transaction (most typical) mode.
+As a possible workaround, you can provide additional parameter to config:
+
+```
+config :my_app, MyApp.EventStore,
+  url: "postgres://postgres:pgbouncer-in-transaction-mode@localhost/eventstore"
+  session_mode_url: "postgres://postgres:pgbouncer-in-session-mode@localhost/eventstore"
+```
+
+And it will use your regular pool settings to connect to database defined `url` and it will establish two connections to `session_mode_url` - which you should point to PGBouncer in session mode or regular postgres instance.

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -105,7 +105,7 @@ defmodule EventStore.Config do
 
   def postgrex_notifications_opts(config, name) do
     config
-    |> Keyword.get(:notification_pool, config)
+    |> Keyword.get(:session_mode_pool, config)
     |> default_postgrex_opts()
     |> Keyword.put(:auto_reconnect, true)
     |> Keyword.put(:backoff_type, :exp)
@@ -122,6 +122,7 @@ defmodule EventStore.Config do
   """
   def advisory_locks_postgrex_opts(config) do
     config
+    |> Keyword.get(:session_mode_pool, config)
     |> default_postgrex_opts()
     |> Keyword.put(:backoff_type, :stop)
     |> Keyword.put(:pool_size, 1)

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -105,6 +105,7 @@ defmodule EventStore.Config do
 
   def postgrex_notifications_opts(config, name) do
     config
+    |> Keyword.get(:notification_pool, config)
     |> default_postgrex_opts()
     |> Keyword.put(:auto_reconnect, true)
     |> Keyword.put(:backoff_type, :exp)

--- a/lib/event_store/config/parser.ex
+++ b/lib/event_store/config/parser.ex
@@ -7,6 +7,9 @@ defmodule EventStore.Config.Parser do
       {:url, value}, config ->
         Keyword.merge(config, value |> get_config_value() |> parse_url())
 
+      {:notification_url, value}, config ->
+        Keyword.merge(config, [notification_pool: value |> get_config_value() |> parse_url()])
+
       {key, value}, config when key in [:port, :timeout] ->
         Keyword.put(config, key, get_config_integer(value))
 

--- a/lib/event_store/config/parser.ex
+++ b/lib/event_store/config/parser.ex
@@ -8,7 +8,7 @@ defmodule EventStore.Config.Parser do
         Keyword.merge(config, value |> get_config_value() |> parse_url())
 
       {:session_mode_url, value}, config ->
-        Keyword.merge(config, [session_mode_pool: value |> get_config_value() |> parse_url()])
+        Keyword.merge(config, session_mode_pool: value |> get_config_value() |> parse_url())
 
       {key, value}, config when key in [:port, :timeout] ->
         Keyword.put(config, key, get_config_integer(value))

--- a/lib/event_store/config/parser.ex
+++ b/lib/event_store/config/parser.ex
@@ -7,8 +7,8 @@ defmodule EventStore.Config.Parser do
       {:url, value}, config ->
         Keyword.merge(config, value |> get_config_value() |> parse_url())
 
-      {:notification_url, value}, config ->
-        Keyword.merge(config, [notification_pool: value |> get_config_value() |> parse_url()])
+      {:session_mode_url, value}, config ->
+        Keyword.merge(config, [session_mode_pool: value |> get_config_value() |> parse_url()])
 
       {key, value}, config when key in [:port, :timeout] ->
         Keyword.put(config, key, get_config_integer(value))

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -113,6 +113,24 @@ defmodule EventStore.ConfigTest do
              ]
   end
 
+  test "parse session_mode_url" do
+    config = [session_mode_url: "postgres://username:password@localhost/database"]
+
+    assert Config.parse(config) ==
+             [
+               enable_hard_deletes: false,
+               column_data_type: "bytea",
+               schema: "public",
+               pool: DBConnection.ConnectionPool,
+               session_mode_pool: [
+                 username: "username",
+                 password: "password",
+                 database: "database",
+                 hostname: "localhost"
+               ]
+             ]
+  end
+
   test "parse url with query parameters" do
     config = [
       url: "postgres://username:password@localhost/database?ssl=true&pool_size=5&timeout=120000"


### PR DESCRIPTION
When using PGBouncer - we have three modes to choose: SESSION, TRANSACTION and STATEMENT.

Out of this three - only when in SESSION mode, we can use `LISTEN`. On the other other hand, using TRANSACTION mode makes scaling way easier.

This PR adds option to provide arbitrary configuration for notifications and locks, which will open two connections (using given url), allowing to use regular Postgres connection with TRANSACTION mode and only these two (which are needed) in SESSION mode.