### PR TITLE
fix: allow parameters to be pass to the event store connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.4.1
+
+- Allow `:parameters` to in the `EventStore` connection ([#257](https://github.com/commanded/eventstore/pull/257))
+    
+  ```elixir
+    config :myapp, MyApp.EventStore,
+      parameters: [application_name: "myapp"]
+  ```
+
 ## v1.4.0
 
 - List running event store instances ([#244](https://github.com/commanded/eventstore/pull/244)).

--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -84,7 +84,8 @@ defmodule EventStore.Config do
     :pool_size,
     :queue_target,
     :queue_interval,
-    :socket_options
+    :socket_options,
+    :parameters
   ]
 
   def default_postgrex_opts(config) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule EventStore.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/commanded/eventstore"
-  @version "1.4.0"
+  @version "1.4.1"
 
   def project do
     [

--- a/test/event_store_test.exs
+++ b/test/event_store_test.exs
@@ -8,6 +8,40 @@ defmodule EventStore.EventStoreTest do
   @all_stream "$all"
   @subscription_name "test_subscription"
 
+  describe "setting application parameters" do
+    test "successfully connects with the application name setup", %{conn: conn} do
+      start_supervised!({TestEventStore, name: :app_name_test, parameters: [application_name: "event_store_test"]})
+
+      result =
+        Postgrex.query!(
+          conn,
+          """
+          SELECT psa.application_name
+          FROM pg_stat_activity as psa
+          WHERE psa.application_name = 'event_store_test'
+          """,
+          []
+        )
+
+      assert result.num_rows > 0
+    end
+
+    test "default connections do not have application name setup", %{conn: conn} do
+      result =
+        Postgrex.query!(
+          conn,
+          """
+          SELECT psa.application_name
+          FROM pg_stat_activity as psa
+          WHERE psa.application_name = 'event_store_test'
+          """,
+          []
+        )
+
+      assert result.num_rows == 0
+    end
+  end
+
   test "returns already started for started event store" do
     assert {:error, {:already_started, _}} = EventStore.start_link()
   end


### PR DESCRIPTION
Allow `:parameters` option to be passed to the EventStore database connection.

```elixir
config :my_app, MyApp.EventStore,,
  parameters: [application_name: "my_app"]
```