### PR TITLE
Prevent forwarding DOWN message to observing process, when monitor pr…

### DIFF
--- a/lib/event_store/monitored_server.ex
+++ b/lib/event_store/monitored_server.ex
@@ -141,6 +141,14 @@ defmodule EventStore.MonitoredServer do
     {:noreply, on_process_exit(pid, reason, state)}
   end
 
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %State{} = state) do
+    %State{monitors: monitors} = state
+
+    state = %State{state | monitors: Map.delete(monitors, pid)}
+
+    {:noreply, state}
+  end
+
   def handle_info(msg, %State{pid: nil} = state) do
     {:noreply, enqueue({:info, msg}, state)}
   end

--- a/test/support/monitoring_server.ex
+++ b/test/support/monitoring_server.ex
@@ -1,7 +1,9 @@
-defmodule EventStore.ObservedServer do
+defmodule EventStore.MonitoringServer do
   @moduledoc false
 
   use GenServer
+
+  alias alias EventStore.MonitoredServer
 
   def start_link(opts) do
     {start_opts, observer_opts} =
@@ -22,25 +24,7 @@ defmodule EventStore.ObservedServer do
     end
   end
 
-  def handle_call(:ping, _from, reply_to) do
-    {:reply, {:ok, :pong}, reply_to}
-  end
-
-  def handle_cast(:ping, reply_to) do
-    send(reply_to, :pong)
-
-    {:noreply, reply_to}
-  end
-
-  def handle_info(:ping, reply_to) do
-    send(reply_to, :pong)
-
-    {:noreply, reply_to}
-  end
-
-  def handle_info({:DOWN, _ref, :process, _pid, _reason} = msg, reply_to) do
-    send(reply_to, msg)
-
-    {:noreply, reply_to}
+  def handle_call({:monitor, name}, _from, reply_to) do
+    {:reply, MonitoredServer.monitor(name), reply_to}
   end
 end


### PR DESCRIPTION
…ocess exists.

I've observed lot of following errors logs when running tests on one of my projects, despite successful tests.

```
10:33:29.698 [error] gen_server <0.10703.0> terminated with reason: no function clause matching 'Elixir.DBConnection.ConnectionPool':handle_info({'DOWN',#Ref<0.1145699320.2707685377.197588>,process,<0.10706.0>,shutdown}, {ready,#Ref<0.1145699320.2707816451.176105>,#{delay => 0,idle => #Ref<0.1145699320.2707685377.197585>,...},...}) line 73
```
Eventually I think I was able to trace the root cause to this dependency.

When monitoring the underlying process [here](https://github.com/commanded/eventstore/blob/master/lib/event_store/monitored_server.ex#L81) and [here](https://github.com/commanded/eventstore/blob/master/lib/event_store/monitored_server.ex#L93) the MonitoredServer will monitor for the caller process as well. Once the caller process exists, a DOWN message will not be handled by the MonitoredServer, but it will be passed to underlying process. I believe the intention here was when the caller process exists, its monitor is removed from state. 

I believe the error we were receiving were originating from the [supervisor](https://github.com/commanded/eventstore/blob/master/lib/event_store/supervisor.ex#L70-L84) during the shutdown. When the AdvisoryLocks process exists, a DOWN message is sent to MonitoredServer due to [AdvisoryLock monitor](https://github.com/commanded/eventstore/blob/master/lib/event_store/advisory_locks.ex#L57). When this message gets received it's being passed down to underlying process, which is `DBConnection.ConnectionPool` in our case.

Possible resolves https://github.com/elixir-ecto/db_connection/issues/214.