### PR TITLE
fix: allow disconnect_on_error_codes to be pass to the event store conn

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -85,7 +85,8 @@ defmodule EventStore.Config do
     :queue_target,
     :queue_interval,
     :socket_options,
-    :parameters
+    :parameters,
+    :disconnect_on_error_codes
   ]
 
   def default_postgrex_opts(config) do


### PR DESCRIPTION
fix: allow disconnect_on_error_codes to be pass to the event store connnection