### PR TITLE
Quote schema names in SQL

### DIFF
--- a/lib/event_store/sql/init.ex
+++ b/lib/event_store/sql/init.ex
@@ -8,7 +8,7 @@ defmodule EventStore.Sql.Init do
     schema = Keyword.fetch!(config, :schema)
 
     [
-      "SET LOCAL search_path TO #{schema};",
+      ~s/SET LOCAL search_path TO "#{schema}";/,
       create_streams_table(),
       create_stream_uuid_index(),
       create_events_table(column_data_type),
@@ -33,7 +33,7 @@ defmodule EventStore.Sql.Init do
   end
 
   defp create_streams_table do
-    """
+   """
     CREATE TABLE streams
     (
         stream_id bigserial PRIMARY KEY NOT NULL,

--- a/lib/event_store/sql/reset.ex
+++ b/lib/event_store/sql/reset.ex
@@ -7,8 +7,8 @@ defmodule EventStore.Sql.Reset do
     schema = Keyword.fetch!(config, :schema)
 
     [
-      "SET LOCAL search_path TO #{schema};",
-      "SET LOCAL eventstore.reset TO 'on'",
+      ~s/SET LOCAL search_path TO "#{schema}";/,
+      ~s/SET LOCAL eventstore.reset TO 'on'/,
       truncate_tables(),
       seed_all_stream()
     ]

--- a/lib/event_store/sql/statements/advisory_unlock.sql.eex
+++ b/lib/event_store/sql/statements/advisory_unlock.sql.eex
@@ -1,4 +1,4 @@
 SELECT pg_advisory_unlock(
-  '<%= schema %>.subscriptions'::regclass::oid::int,
+  '"<%= schema %>".subscriptions'::regclass::oid::int,
   (CASE WHEN $1 > 2147483647 THEN mod($1, 2147483647) ELSE $1 END)::int
 );

--- a/lib/event_store/sql/statements/count_streams.sql.eex
+++ b/lib/event_store/sql/statements/count_streams.sql.eex
@@ -1,3 +1,3 @@
 SELECT COUNT(*)
-FROM <%= schema %>.streams
+FROM "<%= schema %>".streams
 WHERE $1::text IS NULL OR stream_uuid LIKE $1::text;

--- a/lib/event_store/sql/statements/create_stream.sql.eex
+++ b/lib/event_store/sql/statements/create_stream.sql.eex
@@ -1,3 +1,3 @@
-INSERT INTO <%= schema %>.streams (stream_uuid)
+INSERT INTO "<%= schema %>".streams (stream_uuid)
 VALUES ($1)
 RETURNING stream_id;

--- a/lib/event_store/sql/statements/delete_snapshot.sql.eex
+++ b/lib/event_store/sql/statements/delete_snapshot.sql.eex
@@ -1,2 +1,2 @@
-DELETE FROM <%= schema %>.snapshots
+DELETE FROM "<%= schema %>".snapshots
 WHERE source_uuid = $1;

--- a/lib/event_store/sql/statements/delete_subscription.sql.eex
+++ b/lib/event_store/sql/statements/delete_subscription.sql.eex
@@ -1,2 +1,2 @@
-DELETE FROM <%= schema %>.subscriptions
+DELETE FROM "<%= schema %>".subscriptions
 WHERE stream_uuid = $1 AND subscription_name = $2;

--- a/lib/event_store/sql/statements/hard_delete_stream.sql.eex
+++ b/lib/event_store/sql/statements/hard_delete_stream.sql.eex
@@ -1,16 +1,16 @@
 WITH deleted_stream_events AS (
-  DELETE FROM <%= schema %>.stream_events
+  DELETE FROM "<%= schema %>".stream_events
   WHERE stream_id = $1
   RETURNING event_id
 ),
 linked_events AS (
-  DELETE FROM <%= schema %>.stream_events
+  DELETE FROM "<%= schema %>".stream_events
   WHERE event_id IN (SELECT event_id FROM deleted_stream_events)
 ),
 events AS (
-  DELETE FROM <%= schema %>.events
+  DELETE FROM "<%= schema %>".events
   WHERE event_id IN (SELECT event_id FROM deleted_stream_events)
 )
-DELETE FROM <%= schema %>.streams
+DELETE FROM "<%= schema %>".streams
 WHERE stream_id = $1
 RETURNING stream_id;

--- a/lib/event_store/sql/statements/insert_events.sql.eex
+++ b/lib/event_store/sql/statements/insert_events.sql.eex
@@ -7,7 +7,7 @@ WITH
     <% end %>
   ),
   events AS (
-    INSERT INTO <%= schema %>.events
+    INSERT INTO "<%= schema %>".events
       (
         event_id,
         event_type,
@@ -25,18 +25,18 @@ WITH
   ),
   stream AS (
     <%= if stream_id do %>
-      UPDATE <%= schema %>.streams
+      UPDATE "<%= schema %>".streams
       SET stream_version = stream_version + $2::bigint
       WHERE stream_id = $1::bigint
       returning stream_id
     <% else %>
-      INSERT INTO <%= schema %>.streams (stream_uuid, stream_version)
+      INSERT INTO "<%= schema %>".streams (stream_uuid, stream_version)
       VALUES ($1, $2::bigint)
       returning stream_id
     <% end %>
   ),
   source_stream_events AS (
-    INSERT INTO <%= schema %>.stream_events
+    INSERT INTO "<%= schema %>".stream_events
       (
         event_id,
         stream_id,
@@ -53,12 +53,12 @@ WITH
     FROM new_events_indexes, stream
   ),
   linked_stream AS (
-    UPDATE <%= schema %>.streams
+    UPDATE "<%= schema %>".streams
     SET stream_version = stream_version + $2::bigint
     WHERE stream_id = 0
     RETURNING stream_version - $2::bigint as initial_stream_version
   )
-INSERT INTO <%= schema %>.stream_events
+INSERT INTO "<%= schema %>".stream_events
 (
   event_id,
   stream_id,

--- a/lib/event_store/sql/statements/insert_events_any_version.sql.eex
+++ b/lib/event_store/sql/statements/insert_events_any_version.sql.eex
@@ -1,12 +1,12 @@
 WITH
   stream AS (
     <%= if stream_id do %>
-      UPDATE <%= schema %>.streams
+      UPDATE "<%= schema %>".streams
       SET stream_version = stream_version + $2::bigint
       WHERE stream_id = $1::bigint
       returning stream_id, stream_version - $2::bigint as initial_stream_version
     <% else %>
-      INSERT INTO <%= schema %>.streams (stream_uuid, stream_version)
+      INSERT INTO "<%= schema %>".streams (stream_uuid, stream_version)
       VALUES ($1, $2::bigint)
       returning stream_id, stream_version - $2::bigint as initial_stream_version
     <% end %>
@@ -19,7 +19,7 @@ WITH
     <% end %>
   ),
   events AS (
-    INSERT INTO <%= schema %>.events
+    INSERT INTO "<%= schema %>".events
       (
         event_id,
         event_type,
@@ -36,7 +36,7 @@ WITH
     <% end %>
   ),
   source_stream_events AS (
-    INSERT INTO <%= schema %>.stream_events
+    INSERT INTO "<%= schema %>".stream_events
       (
         event_id,
         stream_id,
@@ -53,12 +53,12 @@ WITH
     FROM new_events_indexes, stream
   ),
   linked_stream AS (
-    UPDATE <%= schema %>.streams
+    UPDATE "<%= schema %>".streams
     SET stream_version = stream_version + $2::bigint
     WHERE stream_id = 0
     RETURNING stream_version - $2::bigint as initial_stream_version
   )
-INSERT INTO <%= schema %>.stream_events
+INSERT INTO "<%= schema %>".stream_events
 (
   event_id,
   stream_id,

--- a/lib/event_store/sql/statements/insert_link_events.sql.eex
+++ b/lib/event_store/sql/statements/insert_link_events.sql.eex
@@ -1,6 +1,6 @@
 WITH
   stream AS (
-    UPDATE <%= schema %>.streams
+    UPDATE "<%= schema %>".streams
     SET stream_version = stream_version + $2::bigint
     WHERE stream_id = $1::bigint
     RETURNING stream_version - $2 as initial_stream_version
@@ -8,11 +8,11 @@ WITH
   linked_events (index, event_id) AS (
     VALUES
     <%= for i <- 0..(number_of_events - 1) do %>
-      <%= unless i == 0 do %>,<% end %>    
+      <%= unless i == 0 do %>,<% end %>
       ($<%= i * 2 + 3 %>::bigint, $<%= i * 2 + 4 %>::uuid)
     <% end %>
   )
-INSERT INTO <%= schema %>.stream_events
+INSERT INTO "<%= schema %>".stream_events
   (
     stream_id,
     stream_version,
@@ -28,6 +28,6 @@ SELECT
   original_stream_events.stream_version
 FROM linked_events
 CROSS JOIN stream
-INNER JOIN <%= schema %>.stream_events as original_stream_events
+INNER JOIN "<%= schema %>".stream_events as original_stream_events
   ON original_stream_events.event_id = linked_events.event_id
     AND original_stream_events.stream_id = original_stream_events.original_stream_id;

--- a/lib/event_store/sql/statements/insert_snapshot.sql.eex
+++ b/lib/event_store/sql/statements/insert_snapshot.sql.eex
@@ -1,4 +1,4 @@
-INSERT INTO <%= schema %>.snapshots 
+INSERT INTO "<%= schema %>".snapshots
   (
     source_uuid,
     source_version,

--- a/lib/event_store/sql/statements/insert_subscription.sql.eex
+++ b/lib/event_store/sql/statements/insert_subscription.sql.eex
@@ -1,4 +1,4 @@
-INSERT INTO <%= schema %>.subscriptions
+INSERT INTO "<%= schema %>".subscriptions
   (
     stream_uuid,
     subscription_name,

--- a/lib/event_store/sql/statements/query_all_subscriptions.sql.eex
+++ b/lib/event_store/sql/statements/query_all_subscriptions.sql.eex
@@ -4,5 +4,5 @@ SELECT
   subscription_name,
   last_seen,
   created_at
-FROM <%= schema %>.subscriptions
+FROM "<%= schema %>".subscriptions
 ORDER BY created_at;

--- a/lib/event_store/sql/statements/query_snapshot.sql.eex
+++ b/lib/event_store/sql/statements/query_snapshot.sql.eex
@@ -5,5 +5,5 @@ SELECT
   data,
   metadata,
   created_at
-FROM <%= schema %>.snapshots
+FROM "<%= schema %>".snapshots
 WHERE source_uuid = $1;

--- a/lib/event_store/sql/statements/query_stream_events_backward.sql.eex
+++ b/lib/event_store/sql/statements/query_stream_events_backward.sql.eex
@@ -9,9 +9,9 @@ SELECT
   e.data,
   e.metadata,
   e.created_at
-FROM <%= schema %>.stream_events se
-INNER JOIN <%= schema %>.streams s ON s.stream_id = se.original_stream_id
-INNER JOIN <%= schema %>.events e ON se.event_id = e.event_id
+FROM "<%= schema %>".stream_events se
+INNER JOIN "<%= schema %>".streams s ON s.stream_id = se.original_stream_id
+INNER JOIN "<%= schema %>".events e ON se.event_id = e.event_id
 WHERE
   se.stream_id = $1 AND (se.stream_version <= $2 OR $2 = -1)
 ORDER BY

--- a/lib/event_store/sql/statements/query_stream_events_forward.sql.eex
+++ b/lib/event_store/sql/statements/query_stream_events_forward.sql.eex
@@ -9,9 +9,9 @@ SELECT
   e.data,
   e.metadata,
   e.created_at
-FROM <%= schema %>.stream_events se
-INNER JOIN <%= schema %>.streams s ON s.stream_id = se.original_stream_id
-INNER JOIN <%= schema %>.events e ON se.event_id = e.event_id
+FROM "<%= schema %>".stream_events se
+INNER JOIN "<%= schema %>".streams s ON s.stream_id = se.original_stream_id
+INNER JOIN "<%= schema %>".events e ON se.event_id = e.event_id
 WHERE
   se.stream_id = $1 AND se.stream_version >= $2
 ORDER BY

--- a/lib/event_store/sql/statements/query_stream_info.sql.eex
+++ b/lib/event_store/sql/statements/query_stream_info.sql.eex
@@ -4,5 +4,5 @@ SELECT
   stream_version,
   created_at,
   deleted_at
-FROM <%= schema %>.streams
+FROM "<%= schema %>".streams
 WHERE stream_uuid = $1;

--- a/lib/event_store/sql/statements/query_streams.sql.eex
+++ b/lib/event_store/sql/statements/query_streams.sql.eex
@@ -4,7 +4,7 @@ SELECT
   stream_version,
   created_at,
   deleted_at
-FROM <%= schema %>.streams
+FROM "<%= schema %>".streams
 WHERE $1::text IS NULL OR stream_uuid LIKE $1::text
 ORDER BY <%= sort_by %> <%= sort_dir %>
 LIMIT $2 OFFSET $3;

--- a/lib/event_store/sql/statements/query_subscription.sql.eex
+++ b/lib/event_store/sql/statements/query_subscription.sql.eex
@@ -4,5 +4,5 @@ SELECT
   subscription_name,
   last_seen,
   created_at
-FROM <%= schema %>.subscriptions
+FROM "<%= schema %>".subscriptions
 WHERE stream_uuid = $1 AND subscription_name = $2;

--- a/lib/event_store/sql/statements/soft_delete_stream.sql.eex
+++ b/lib/event_store/sql/statements/soft_delete_stream.sql.eex
@@ -1,3 +1,3 @@
-UPDATE <%= schema %>.streams
+UPDATE "<%= schema %>".streams
 SET deleted_at = NOW()
 WHERE stream_id = $1;

--- a/lib/event_store/sql/statements/subscription_ack.sql.eex
+++ b/lib/event_store/sql/statements/subscription_ack.sql.eex
@@ -1,3 +1,3 @@
-UPDATE <%= schema %>.subscriptions
+UPDATE "<%= schema %>".subscriptions
 SET last_seen = $3
 WHERE stream_uuid = $1 AND subscription_name = $2;

--- a/lib/event_store/sql/statements/try_advisory_lock.sql.eex
+++ b/lib/event_store/sql/statements/try_advisory_lock.sql.eex
@@ -1,4 +1,4 @@
 SELECT pg_try_advisory_lock(
-  '<%= schema %>.subscriptions'::regclass::oid::int,
+  '"<%= schema %>".subscriptions'::regclass::oid::int,
   (CASE WHEN $1 > 2147483647 THEN mod($1, 2147483647) ELSE $1 END)::int
 );

--- a/lib/event_store/storage/schema.ex
+++ b/lib/event_store/storage/schema.ex
@@ -6,7 +6,7 @@ defmodule EventStore.Storage.Schema do
   def create(config) do
     schema = Keyword.fetch!(config, :schema)
 
-    case Database.execute(config, "CREATE SCHEMA #{schema}") do
+    case Database.execute(config, ~s/CREATE SCHEMA "#{schema}"/) do
       :ok ->
         :ok
 
@@ -21,7 +21,7 @@ defmodule EventStore.Storage.Schema do
   def drop(config) do
     schema = Keyword.fetch!(config, :schema)
 
-    case Database.execute(config, "DROP SCHEMA #{schema} CASCADE;") do
+    case Database.execute(config, ~s/DROP SCHEMA "#{schema}" CASCADE;/) do
       :ok ->
         :ok
 

--- a/lib/event_store/tasks/migrate.ex
+++ b/lib/event_store/tasks/migrate.ex
@@ -94,7 +94,7 @@ defmodule EventStore.Tasks.Migrate do
       path = Application.app_dir(:eventstore, "priv/event_store/migrations/v#{migration}.sql")
       script = File.read!(path)
 
-      statements = ["SET LOCAL search_path TO #{schema}; ", script]
+      statements = [~s/SET LOCAL search_path TO "#{schema}"; /, script]
 
       case transaction(conn, statements) do
         {:ok, :ok} ->
@@ -129,7 +129,7 @@ defmodule EventStore.Tasks.Migrate do
       conn,
       """
         SELECT major_version, minor_version, patch_version
-        FROM #{schema}.schema_migrations
+        FROM "#{schema}".schema_migrations
       """,
       []
     )

--- a/lib/event_store/tasks/migrations.ex
+++ b/lib/event_store/tasks/migrations.ex
@@ -96,7 +96,7 @@ defmodule EventStore.Tasks.Migrations do
     config
     |> run_query("""
       SELECT major_version, minor_version, patch_version, migrated_at
-      FROM #{schema}.schema_migrations
+      FROM "#{schema}".schema_migrations
       ORDER BY 1, 2, 3
     """)
     |> handle_response()


### PR DESCRIPTION
For tests I was generating schema names that contain a dash, which is valid in PostgreSQL as long as you double-quote the schema name. I think I've caught everything here.