### PR TITLE
Terminate a monitored process only if there are no other processes registered to use it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['24.3', '25.1']
-        elixir: ['1.14.1']
+        otp: ['24.3', '25.3']
+        elixir: ['1.14.5']
 
     services:
       postgres:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.1-otp-24
-erlang 24.3.4.6
+elixir 1.14.5-otp-25
+erlang 25.3.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Allow `disconnect_on_error_codes` to be passed to the event store Postgrex connection ([#263](https://github.com/commanded/eventstore/pull/263)).
 * Support all `Postgrex` and `DBConnection` options when configuring an event store ([#273](https://github.com/commanded/eventstore/pull/273)).
 
+### Bug fixes
+
+* Terminate a monitored process only if there are no other processes registered to use it ([#272](https://github.com/commanded/eventstore/pull/272)).
+
 ## v1.4.1
 
 ### Enhancements

--- a/lib/event_store/application.ex
+++ b/lib/event_store/application.ex
@@ -5,7 +5,8 @@ defmodule EventStore.Application do
 
   def start(_type, _args) do
     children = [
-      EventStore.Config.Store
+      EventStore.Config.Store,
+      {Registry, keys: :duplicate, name: MonitoredServer.Registry}
     ]
 
     opts = [strategy: :one_for_one, name: EventStore.Supervisor]

--- a/test/monitored_server_test.exs
+++ b/test/monitored_server_test.exs
@@ -1,16 +1,19 @@
 defmodule EventStore.MonitoredServerTest do
   use ExUnit.Case
 
-  alias EventStore.{MonitoredServer, ObservedServer, ProcessHelper}
+  alias EventStore.{MonitoredServer, ObservedServer, ProcessHelper, Wait}
 
   describe "monitored server" do
     test "should start process" do
-      start_monitored_process!()
+      {monitor, ref} = start_monitored_process!()
 
       assert_receive {:init, pid}
 
       assert Process.whereis(ObservedServer) == pid
       assert Process.alive?(pid)
+
+      assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+      assert monitors == %{self() => ref}
     end
 
     test "should stop observed process when monitored process stopped" do
@@ -26,7 +29,7 @@ defmodule EventStore.MonitoredServerTest do
     end
 
     test "should restart process after exit" do
-      start_monitored_process!()
+      {monitor, ref} = start_monitored_process!()
 
       assert_receive {:init, pid1}
 
@@ -38,6 +41,9 @@ defmodule EventStore.MonitoredServerTest do
       assert pid1 != pid2
       refute Process.alive?(pid1)
       assert Process.alive?(pid2)
+
+      assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+      assert monitors == %{self() => ref}
     end
 
     test "should retry start on failure" do
@@ -57,6 +63,28 @@ defmodule EventStore.MonitoredServerTest do
       shutdown_observed_process()
 
       assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+    end
+
+    test "should send `:DOWN` message after process crash" do
+      {monitor, ref} = start_monitored_process!()
+
+      assert_receive {:init, pid1}
+      refute_receive {:DOWN, _ref, :process, _pid, _reason}
+
+      assert :ok = GenServer.cast(MonitoredServer, :crash)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid1, {%RuntimeError{message: "crash"}, _}}
+
+      # Should restart the crashed process
+      assert_receive {:init, pid2}
+
+      assert is_pid(pid2)
+      assert pid1 != pid2
+      refute Process.alive?(pid1)
+      assert Process.alive?(pid2)
+
+      assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+      assert monitors == %{self() => ref}
     end
 
     test "should forward calls to observed process using registered name" do
@@ -94,12 +122,15 @@ defmodule EventStore.MonitoredServerTest do
 
       assert {:ok, :pong} = GenServer.call(pid, :ping)
 
-      {monitor, _ref} = start_monitored_process!()
+      {monitor, ref} = start_monitored_process!()
 
       assert {:ok, :pong} = GenServer.call(monitor, :ping)
+
+      assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+      assert monitors == %{self() => ref}
     end
 
-    test "stopping monitored observer associated with an already started process should not terminate process" do
+    test "stopping monitored observer associated with an already started process should terminate process" do
       pid = start_supervised!({ObservedServer, reply_to: self(), name: ObservedServer})
 
       start_monitored_process!()
@@ -110,13 +141,13 @@ defmodule EventStore.MonitoredServerTest do
 
       :ok = stop_supervised(MonitoredServer)
 
-      refute_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
     end
 
     test "monitored observer should attempt to restart an already started process on exit" do
       pid1 = start_supervised!({ObservedServer, reply_to: self(), name: ObservedServer})
 
-      {_pid, ref} = start_monitored_process!()
+      {_monitor, ref} = start_monitored_process!()
 
       assert_receive {:init, ^pid1}
 
@@ -126,6 +157,71 @@ defmodule EventStore.MonitoredServerTest do
       assert_receive {:init, pid2}
 
       refute pid1 == pid2
+    end
+
+    test "stopping all monitored servers should terminate monitored process" do
+      start_supervised!(
+        {MonitoredServer,
+         mfa: {ObservedServer, :start_link, [[reply_to: self(), name: ObservedServer]]},
+         name: MonitoredServer1,
+         backoff_min: 1,
+         backoff_max: 100},
+        id: MonitoredServer1
+      )
+
+      start_supervised!(
+        {MonitoredServer,
+         mfa: {ObservedServer, :start_link, [[reply_to: self(), name: ObservedServer]]},
+         name: MonitoredServer2,
+         backoff_min: 1,
+         backoff_max: 100},
+        id: MonitoredServer2
+      )
+
+      assert_receive {:init, pid}
+      refute_received {:init, _pid}
+
+      ref = Process.monitor(pid)
+
+      :ok = stop_supervised(MonitoredServer1)
+
+      # Monitored process should still be alive after only stopping one assocated monitor
+      refute_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+
+      :ok = stop_supervised(MonitoredServer2)
+
+      # Monitored process should be terminated when both monitors have been stopped
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+    end
+
+    test "should remove monitor when process terminates" do
+      reply_to = self()
+
+      {monitor, ref1} = start_monitored_process!()
+
+      pid =
+        spawn(fn ->
+          {:ok, ref} = MonitoredServer.monitor(MonitoredServer)
+
+          send(reply_to, {:monitored, ref})
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive {:monitored, ref2}
+
+      assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+      assert monitors == %{self() => ref1, pid => ref2}
+
+      send(pid, :stop)
+
+      # Should remove terminated monitoring process from monitors
+      Wait.until(fn ->
+        assert {:ok, monitors} = MonitoredServer.monitors(monitor)
+        assert monitors == %{self() => ref1}
+      end)
     end
   end
 

--- a/test/support/observed_server.ex
+++ b/test/support/observed_server.ex
@@ -26,6 +26,10 @@ defmodule EventStore.ObservedServer do
     {:reply, {:ok, :pong}, reply_to}
   end
 
+  def handle_cast(:crash, _state) do
+    raise RuntimeError, message: "crash"
+  end
+
   def handle_cast(:ping, reply_to) do
     send(reply_to, :pong)
 


### PR DESCRIPTION
When using a shared database connection pool amongst event stores the Postgrex database connection should _only_ be stopped when all event stores using the connection have been stopped. 

Previously the event store which started the Postgrex connection was responsible for terminating it. This was problematic if using dynamic event stores which may be started and stopped in any order. If the event store which started first and which started the shared connection pool was later stopped then any other event stores using the same connection pool could encounter an issue until the connection was restarted by one of them.