### PR TITLE
Fix: Parse url with encoded hash in password

### DIFF
--- a/lib/event_store/config/parser.ex
+++ b/lib/event_store/config/parser.ex
@@ -39,7 +39,7 @@ defmodule EventStore.Config.Parser do
   defp parse_url(""), do: []
 
   defp parse_url(url) do
-    info = url |> URI.decode() |> URI.parse()
+    info = URI.parse(url)
 
     if is_nil(info.host) do
       raise ArgumentError, message: "host is not present"

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -110,6 +110,22 @@ defmodule EventStore.ConfigTest do
     )
   end
 
+  test "parse url with encoded hash in password" do
+    config = [url: "postgres://username:password%23with_hash@localhost/database"]
+
+    assert_parsed_config(config,
+      enable_hard_deletes: false,
+      column_data_type: "bytea",
+      schema: "public",
+      timeout: 15_000,
+      pool: EventStore.Config.get_pool(),
+      username: "username",
+      password: "password#with_hash",
+      database: "database",
+      hostname: "localhost"
+    )
+  end
+
   test "parse session_mode_url" do
     config = [session_mode_url: "postgres://username:password@localhost/database"]
 


### PR DESCRIPTION
# Actual
```ex
# config.exs
config :my_app, MyApp.EventStore,
  url: "postgres://username:password%23with_hash@localhost/database"
```
Error: `path should be a database name`

# Expected
No error, connects to database with decoded password `password#with_hash`.

# Details
URI was decoded twice: [`parser.ex:42`](https://github.com/commanded/eventstore/blob/master/lib/event_store/config/parser.ex#L42) and [`parser.ex:71`](https://github.com/commanded/eventstore/blob/master/lib/event_store/config/parser.ex#L71)