### PR TITLE
Allow configuring the default database

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -41,6 +41,14 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
         url: "postgres://postgres:postgres@localhost/eventstore"
       ```
 
+
+      **Note:** Some managed database providers (such as DigitalOcean) don't provide access to the default `postgres` database. In such case, you can specify a default database in the following way:
+
+      ```elixir
+      config :my_app, MyApp.EventStore,
+        default_database: "defaultdb",
+      ```
+
       **Note:** To use an EventStore with Commanded you should configure the event
       store to use Commanded's JSON serializer which provides additional support for
       JSON decoding:

--- a/lib/event_store/storage/database.ex
+++ b/lib/event_store/storage/database.ex
@@ -89,7 +89,9 @@ defmodule EventStore.Storage.Database do
         raise ":database is nil in repository configuration"
 
     encoding = opts[:encoding] || "UTF8"
-    opts = Keyword.put(opts, :database, "postgres")
+
+    default_database = Keyword.get(opts, :default_database, "postgres")
+    opts = Keyword.put(opts, :database, default_database)
 
     command =
       ~s(CREATE DATABASE "#{database}" ENCODING '#{encoding}')
@@ -117,7 +119,9 @@ defmodule EventStore.Storage.Database do
       Keyword.fetch!(opts, :database) || raise ":database is nil in repository configuration"
 
     command = "DROP DATABASE \"#{database}\""
-    opts = Keyword.put(opts, :database, "postgres")
+
+    default_database = Keyword.get(opts, :default_database, "postgres")
+    opts = Keyword.put(opts, :database, default_database)
 
     case run_query(command, opts) do
       {:ok, _} ->


### PR DESCRIPTION
The current configuration assumes that the default database will always be `postgres`. This doesn't work with some managed database providers (such as DigitalOcean), which don't allow access to the `postgres` database.

This PR makes it possible to configure the default database name.