### PR TITLE
Fix unused read batch size

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -533,6 +533,12 @@ defmodule EventStore do
         conn = Keyword.get(opts, :conn) || Keyword.fetch!(config, :conn)
         timeout = timeout(opts, config)
 
+        config =
+          case Keyword.fetch(opts, :read_batch_size) do
+            {:ok, read_batch_size} -> Keyword.put(config, :read_batch_size, read_batch_size)
+            :error -> config
+          end
+
         {conn, Keyword.put(config, :timeout, timeout)}
       end
 


### PR DESCRIPTION
In various functions the default read batch size was put using `put_new`, but any passed value was not considered, e.g.: https://github.com/commanded/eventstore/pull/279/files#diff-5859174eceff3693f45c15a51637712f36a541644a3ee51696d38518a2d229e9R376-R378