### PR TITLE
Create stream before appending to it.

### DIFF
--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -22,6 +22,7 @@ defmodule EventStore.Streams.Stream do
       conn,
       fn transaction ->
         with {:ok, stream} <- stream_info(transaction, stream_uuid, expected_version, new_opts),
+             {:ok, stream} <- prepare_stream(transaction, stream, opts),
              :ok <-
                do_append_to_storage(
                  transaction,


### PR DESCRIPTION
This should handle the case where we append more than 1 batch of events to a new stream.

Should fix https://github.com/commanded/eventstore/issues/283