### PR TITLE
Remember the generated stream_id across batches of events being appeneded.

### DIFF
--- a/lib/event_store/sql/statements/insert_events.sql.eex
+++ b/lib/event_store/sql/statements/insert_events.sql.eex
@@ -57,20 +57,24 @@ WITH
     SET stream_version = stream_version + $2::bigint
     WHERE stream_id = 0
     RETURNING stream_version - $2::bigint as initial_stream_version
+  ),
+  linked_stream_events AS (
+    INSERT INTO "<%= schema %>".stream_events
+    (
+      event_id,
+      stream_id,
+      stream_version,
+      original_stream_id,
+      original_stream_version
+    )
+    SELECT
+      new_events_indexes.event_id,
+      0,
+      linked_stream.initial_stream_version + new_events_indexes.index,
+      stream.stream_id,
+      new_events_indexes.stream_version
+    FROM
+      new_events_indexes, linked_stream, stream
   )
-INSERT INTO "<%= schema %>".stream_events
-(
-  event_id,
-  stream_id,
-  stream_version,
-  original_stream_id,
-  original_stream_version
-)
-SELECT
-  new_events_indexes.event_id,
-  0,
-  linked_stream.initial_stream_version + new_events_indexes.index,
-  stream.stream_id,
-  new_events_indexes.stream_version
-FROM
-  new_events_indexes, linked_stream, stream;
+
+SELECT stream_id from stream;

--- a/lib/event_store/sql/statements/insert_events_any_version.sql.eex
+++ b/lib/event_store/sql/statements/insert_events_any_version.sql.eex
@@ -57,20 +57,24 @@ WITH
     SET stream_version = stream_version + $2::bigint
     WHERE stream_id = 0
     RETURNING stream_version - $2::bigint as initial_stream_version
+  ),
+  linked_stream_events AS (
+    INSERT INTO "<%= schema %>".stream_events
+    (
+      event_id,
+      stream_id,
+      stream_version,
+      original_stream_id,
+      original_stream_version
+    )
+    SELECT
+      new_events_indexes.event_id,
+      0,
+      linked_stream.initial_stream_version + new_events_indexes.index,
+      stream.stream_id,
+      stream.initial_stream_version + new_events_indexes.index
+    FROM
+      new_events_indexes, linked_stream, stream
   )
-INSERT INTO "<%= schema %>".stream_events
-(
-  event_id,
-  stream_id,
-  stream_version,
-  original_stream_id,
-  original_stream_version
-)
-SELECT
-  new_events_indexes.event_id,
-  0,
-  linked_stream.initial_stream_version + new_events_indexes.index,
-  stream.stream_id,
-  stream.initial_stream_version + new_events_indexes.index
-FROM
-  new_events_indexes, linked_stream, stream;
+
+SELECT stream_id from stream;

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -344,9 +344,7 @@ defmodule EventStore.Streams.Stream do
 
       append_to_stream(conn, stream_uuid, expected_version, events, opts)
     else
-      # We should never get here, but just in case we break something in another
-      # part of the app, this will give us better output in the tests.
-      {:error, :already_retried_once}
+      {:error, {:already_retried_once, :duplicate_stream_uuid}}
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-exclude = [:ignore, :manual, :migration, :slow]
+exclude = [:ignore, :manual, :migration]
 
 ExUnit.start(exclude: exclude)


### PR DESCRIPTION
Addresses #283

By returning and remembering `stream_id` created in the first batch, then subsequent batches no longer fail with a duplicate stream_uuid constraint error.

This has been a long standing issue as mentioned in the issue. It was hidden by excluding `:slow` tests by default. This PR also includes slow tests by default. The test run goes from about 30s to 60s on my machine. 

I think we can close #285 in favour of this one.

Big thanks to @thomasdziedzic for finding this one.
