### PR TITLE
Fillout test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['25.3', '26.2']
-        elixir: ['1.16.0']
+        include:
+          - elixir: 1.17.x
+            otp: 27
+          - elixir: 1.16.x
+            otp: 26
+          - elixir: 1.15.x
+            otp: 26
+          - elixir: 1.14.x
+            otp: 26
+          - elixir: 1.13.x
+            otp: 25
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,9 @@ jobs:
         MIX_ENV=test mix event_store.setup
         MIX_ENV=jsonb mix event_store.setup
 
+    - name: Compile
+      run: mix compile --warnings-as-errors
+
     - name: Run tests
       run: mix test.all
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,10 @@ jobs:
             otp: 26
           - elixir: 1.14.x
             otp: 26
+            check_formatted: "ignore"
           - elixir: 1.13.x
             otp: 25
+            check_formatted: "ignore"
 
     services:
       postgres:
@@ -54,6 +56,7 @@ jobs:
       run: mix deps.get
 
     - name: Check formatting
+      if: ${{ matrix.check_formatted != 'ignore' }}
       run: mix format --check-formatted
 
     - name: Setup EventStore test databases

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
* Adds Elixir 1.13 - 1.17 with their latest supported OTP to the Test matrix
* Compiles with errors as warnings
* Disables mix format check for versions under 1.15 as the format has changed since 
* Now only runs CI on PRs, pushes to master and tags