### PR TITLE
fix: merge session mode pool config with main config, preserving options

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -151,6 +151,7 @@ defmodule EventStore.Config do
   # connections (advisory locks and notifications). Uses the default Postgres
   # configuration if not specified.
   defp session_mode_pool_config(config) do
-    Keyword.get(config, :session_mode_pool, config)
+    config
+    |> Keyword.merge(Keyword.get(config, :session_mode_pool, []))
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -144,6 +144,38 @@ defmodule EventStore.ConfigTest do
     )
   end
 
+  test "passes parent config options to session mode pool config" do
+    config = [
+      ssl: true,
+      ssl_opts: [cacertfile: ~c"/etc/ssl/certs/db.ca-certificate.crt", verify: :verify_peer],
+      prepare: :unnamed,
+      session_mode_url: "postgres://username:password@localhost/database"
+    ]
+
+    session_mode_pool_config =
+      Config.parse(config) |> Config.postgrex_notifications_opts(:name) |> Enum.sort()
+
+    assert session_mode_pool_config == [
+             auto_reconnect: true,
+             backoff_type: :exp,
+             database: "database",
+             hostname: "localhost",
+             name: :name,
+             password: "password",
+             pool: DBConnection.ConnectionPool,
+             pool_size: 1,
+             prepare: :unnamed,
+             ssl: true,
+             ssl_opts: [
+               cacertfile: ~c"/etc/ssl/certs/db.ca-certificate.crt",
+               verify: :verify_peer
+             ],
+             sync_connect: false,
+             timeout: 15000,
+             username: "username"
+           ]
+  end
+
   test "parse url with query parameters" do
     config = [
       url: "postgres://username:password@localhost/database?ssl=true&pool_size=5&timeout=120000"


### PR DESCRIPTION
When providing a session mode pool config via `session_mode_url`, it's not clear that `session_mode_url` is parsed into a keyword list and replaces the parent config.

For example, we use the following configuration to connect to Digital Ocean's managed Postgres:

```elixir
config :our_app, OurApp.EventStore,
  default_database: "defaultdb",
  serializer: Commanded.Serialization.JsonSerializer,
  url: event_store_database_url,
  session_mode_url: event_store_session_database_url,
  ssl: true,
  ssl_opts: [cacertfile: ~c"/etc/ssl/certs/db.ca-certificate.crt", verify: :verify_peer],
  prepare: :unnamed,
  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
  socket_options: maybe_ipv6
```

The options `ssl`, `ssl_opts`, and `prepare` are particularly important to our connection and are not included when generating the config (session mode pool config) from the `session_mode_url`.

This PR merges the session mode pool config _into_ the parent config before passing it along. So that all the specified configuration options are used for the session mode pool, too. Which, I think, is what people probably expect when looking at the above event store configuration.