### PR TITLE
feat: add annotations to subscriptions table

### DIFF
--- a/lib/event_store/sql/init.ex
+++ b/lib/event_store/sql/init.ex
@@ -28,8 +28,22 @@ defmodule EventStore.Sql.Init do
       create_subscription_index(),
       create_snapshots_table(column_data_type),
       create_schema_migrations_table(),
-      record_event_store_schema_version()
+      record_event_store_schema_version(),
+      add_annotations_to_subscriptions(),
+      create_subscription_annotations_index()
     ]
+  end
+
+  defp add_annotations_to_subscriptions do
+    """
+    ALTER TABLE subscriptions ADD COLUMN annotations jsonb;
+    """
+  end
+
+  defp create_subscription_annotations_index do
+    """
+    CREATE INDEX subscriptions_annotations_idx ON subscriptions USING gin (annotations);
+    """
   end
 
   defp create_streams_table do

--- a/lib/event_store/sql/statements/insert_subscription.sql.eex
+++ b/lib/event_store/sql/statements/insert_subscription.sql.eex
@@ -2,7 +2,8 @@ INSERT INTO "<%= schema %>".subscriptions
   (
     stream_uuid,
     subscription_name,
-    last_seen
+    last_seen,
+    annotations
   )
-VALUES ($1, $2, $3)
-RETURNING subscription_id, stream_uuid, subscription_name, last_seen, created_at;
+VALUES ($1, $2, $3, $4)
+RETURNING subscription_id, stream_uuid, subscription_name, last_seen, created_at, annotations;

--- a/lib/event_store/sql/statements/query_all_subscriptions.sql.eex
+++ b/lib/event_store/sql/statements/query_all_subscriptions.sql.eex
@@ -3,6 +3,7 @@ SELECT
   stream_uuid,
   subscription_name,
   last_seen,
-  created_at
+  created_at,
+  annotations
 FROM "<%= schema %>".subscriptions
 ORDER BY created_at;

--- a/lib/event_store/sql/statements/query_subscription.sql.eex
+++ b/lib/event_store/sql/statements/query_subscription.sql.eex
@@ -3,6 +3,7 @@ SELECT
   stream_uuid,
   subscription_name,
   last_seen,
-  created_at
+  created_at,
+  annotations
 FROM "<%= schema %>".subscriptions
 WHERE stream_uuid = $1 AND subscription_name = $2;

--- a/priv/event_store/migrations/v1.4.0.sql
+++ b/priv/event_store/migrations/v1.4.0.sql
@@ -1,0 +1,7 @@
+-- Add annotations field to subscriptions table
+
+ALTER TABLE subscriptions
+ADD COLUMN annotations jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+-- Add index on annotations for better query performance
+CREATE INDEX subscriptions_annotations_idx ON subscriptions USING gin (annotations); 


### PR DESCRIPTION
## Context

The intent is to add information to build Operational dashboards based on such metadata. I need to contact the team owner of such a processor as soon as possible.

- Should this be outside the Event Store?

This is a way to avoid extra infrastructure and tooling, and the code should be the source of truth rather than conforming to more complex organizational structures and more prominent companies' needs.

Here is an example:

```elixir
defmodule ExampleHandler do
  use Commanded.Event.Handler,
    application: ExampleApp,
    name: "ExampleHandler",
    annotations: %{team: "billing"} # made up, pending to discuss in Commanded itself
end
```

## Open Questions

- Should the migration allow `NULL` values?
- Should we do a `merge` when deploying or replace annotations when subscribing?