### PR TITLE
Change partition_by to return a random partition instead of a nil value for a parition_by function

### DIFF
--- a/guides/Subscriptions.md
+++ b/guides/Subscriptions.md
@@ -279,7 +279,7 @@ You can use a `partition_by` function to guarantee ordering of events within a p
 
 Partitioning gives you the benefits of competing consumers but still allows event ordering by partition where required.
 
-If a `partition_by` is not provided or if it returns `nil` - a random integer will be generated for the partition id.
+If a `partition_by` returns `nil`, a random default partition based on the `max_size` will be generated for the partition id.
 
 #### Partition by example
 

--- a/guides/Subscriptions.md
+++ b/guides/Subscriptions.md
@@ -277,8 +277,9 @@ With multiple subscriber processes connected to a single subscription the orderi
 
 You can use a `partition_by` function to guarantee ordering of events within a particular group (e.g. per stream) but still allow events for different groups to be processed concurrently.
 
-
 Partitioning gives you the benefits of competing consumers but still allows event ordering by partition where required.
+
+If a `partition_by` is not provided or if it returns `nil` - a random integer will be generated for the partition id.
 
 #### Partition by example
 

--- a/lib/event_store/subscriptions/subscription_fsm.ex
+++ b/lib/event_store/subscriptions/subscription_fsm.ex
@@ -509,8 +509,8 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
   end
 
   # Use nil partition when there's a lack of a partition_by callback since this way
-  # we maximize parallelization by having EventStore.Subscriptions.Subscriber.in_partition?/2 s
-  # returning false for all events, making sure each event "seeks" a new available subscriber
+  # we maximize parallelization by having EventStore.Subscriptions.Subscriber.in_partition?/2
+  # return false for all events, making sure each event "seeks" a new available subscriber
   def partition_key(%SubscriptionState{partition_by: nil}, %RecordedEvent{}),
     do: nil
 
@@ -526,10 +526,10 @@ defmodule EventStore.Subscriptions.SubscriptionFsm do
       # for nil partition keys - resulting in the nil partition being able
       # to exhaust partitions for all other partitions if it's being used to process
       # a significantly high number of events compared to the other partitions due to
-      # it then always having the priority scheduling due to having most events in queue
+      # it then always having the priority in scheduling due to having most events in queue
       # and its events never reusing existing subscribers but always looking for new ones.
-      # This works well when `partition_by` is nil to maximize parallelization but not ideal
-      # when sharing the scheduler with other partitions
+      # This works well when `partition_by` is nil to maximize parallelization for all events
+      # but not ideal when sharing the scheduler with other partitions
       nil ->
         max_partition =
           if is_integer(max_size) and max_size > 10 do

--- a/test/subscriptions/partition_key_test.exs
+++ b/test/subscriptions/partition_key_test.exs
@@ -16,21 +16,21 @@ defmodule EventStore.Subscriptions.PartitionKeyTest do
       assert partition_key == "some_key"
     end
 
-    test "should return a random integer for a nil callback return" do
+    test "should return a random default partition for a nil callback return" do
       partition_key =
         SubscriptionFsm.partition_key(
           %SubscriptionState{partition_by: fn _ -> nil end},
           %RecordedEvent{}
         )
 
-      assert is_integer(partition_key)
+      assert String.match?(partition_key, ~r/^\$default\.[0-9]+$/)
     end
 
-    test "should return a random integer for a nil callback" do
+    test "should return nil for a nil callback" do
       partition_key =
         SubscriptionFsm.partition_key(%SubscriptionState{partition_by: nil}, %RecordedEvent{})
 
-      assert is_integer(partition_key)
+      assert is_nil(partition_key)
     end
   end
 end

--- a/test/subscriptions/partition_key_test.exs
+++ b/test/subscriptions/partition_key_test.exs
@@ -1,4 +1,4 @@
-defmodule EventStore.Subscriptions.SubscriptionAcknowledgementTest do
+defmodule EventStore.Subscriptions.PartitionKeyTest do
   use ExUnit.Case, async: true
 
   alias EventStore.RecordedEvent

--- a/test/subscriptions/partition_key_test.exs
+++ b/test/subscriptions/partition_key_test.exs
@@ -1,0 +1,36 @@
+defmodule EventStore.Subscriptions.SubscriptionAcknowledgementTest do
+  use ExUnit.Case, async: true
+
+  alias EventStore.RecordedEvent
+  alias EventStore.Subscriptions.SubscriptionFsm
+  alias EventStore.Subscriptions.SubscriptionState
+
+  describe "partition_key/2" do
+    test "should return the value for a non-nil callback return" do
+      partition_key =
+        SubscriptionFsm.partition_key(
+          %SubscriptionState{partition_by: fn _ -> "some_key" end},
+          %RecordedEvent{}
+        )
+
+      assert partition_key == "some_key"
+    end
+
+    test "should return a random integer for a nil callback return" do
+      partition_key =
+        SubscriptionFsm.partition_key(
+          %SubscriptionState{partition_by: fn _ -> nil end},
+          %RecordedEvent{}
+        )
+
+      assert is_integer(partition_key)
+    end
+
+    test "should return a random integer for a nil callback" do
+      partition_key =
+        SubscriptionFsm.partition_key(%SubscriptionState{partition_by: nil}, %RecordedEvent{})
+
+      assert is_integer(partition_key)
+    end
+  end
+end


### PR DESCRIPTION
This fixes an issue we were facing where the `partition_key` being `nil` meant that since 

```elixir
in_partition?(%Subscriber{partition_key: nil}, _partition_key), do: false
```

Then any events with a `nil` `partition_key` would exhaust the available subscribers - draining them from other queues - and especially in our case where 99% of events were going to the `nil` queue - meaning this queue always get priority vs other queues in terms of consuming events. This happened due to in `EventStore.Subscriptions.SubscriptionFsm.next_available_subscriber/2` this never resolving into an existing queue:

```elixir
 partition_subscriber =
      Enum.find(subscribers, fn {_pid, subscriber} ->
        Subscriber.in_partition?(subscriber, partition_key)
      end)
```

which meant that events for the `nil` queue would always grab a new Subscriber instead of grouping up with an existing one already processing a `nil` queue event. This exhausted the subscribers and prevented other queues with less events from being processed.

This fix prevents the issue by replacing `nil` partition_keys with a random partition based on the max_size that will allow the event queues to be processed with equal priority when `partition_by` is `nil` or returns `nil`.

This `nil` behavior was kept for when `partition_by` is `nil` since it optimizes the parallelism of the "default" behavior when no `partition_by` is provided. 