### PR TITLE
Start pubsub supervisor before subscriptions supervisor

### DIFF
--- a/lib/event_store/supervisor.ex
+++ b/lib/event_store/supervisor.ex
@@ -85,13 +85,16 @@ defmodule EventStore.Supervisor do
              conn: advisory_locks_postgrex_conn,
              query_timeout: query_timeout,
              schema: schema,
-             name: advisory_locks_name},
-            {Subscriptions.Supervisor, name: subscriptions_name},
-            Supervisor.child_spec({Registry, keys: :unique, name: subscriptions_registry_name},
-              id: subscriptions_registry_name
-            ),
-            {Notifications.Supervisor, {name, config}}
-          ] ++ PubSub.child_spec(name)
+             name: advisory_locks_name}
+          ] ++
+            PubSub.child_spec(name) ++
+            [
+              {Subscriptions.Supervisor, name: subscriptions_name},
+              Supervisor.child_spec({Registry, keys: :unique, name: subscriptions_registry_name},
+                id: subscriptions_registry_name
+              ),
+              {Notifications.Supervisor, {name, config}}
+            ]
 
         :ok = Config.associate(name, self(), event_store, config)
 

--- a/test/streams/all_stream_test.exs
+++ b/test/streams/all_stream_test.exs
@@ -101,7 +101,6 @@ defmodule EventStore.Streams.AllStreamTest do
       serializer: serializer,
       stream1_uuid: stream1_uuid
     } do
-
       :ok = EventStore.delete_stream(stream1_uuid, :stream_exists, :hard)
 
       read_events =
@@ -209,7 +208,6 @@ defmodule EventStore.Streams.AllStreamTest do
       serializer: serializer,
       stream2_uuid: stream2_uuid
     } do
-
       :ok = EventStore.delete_stream(stream2_uuid, :stream_exists, :hard)
 
       read_events =


### PR DESCRIPTION
Starting the pubsub supervisor before the subscription supervisor eliminates a race condition found here: https://github.com/commanded/commanded/issues/623