### PR TITLE
fix: remove status from sort_by options

### DIFF
--- a/lib/event_store/storage/stream.ex
+++ b/lib/event_store/storage/stream.ex
@@ -67,7 +67,6 @@ defmodule EventStore.Storage.Stream do
         :stream_version -> "stream_version"
         :created_at -> "created_at"
         :deleted_at -> "deleted_at"
-        :status -> "status"
       end
 
     sort_dir =


### PR DESCRIPTION
closes #303

DDL:

```sql
CREATE TABLE streams (
    stream_id BIGSERIAL PRIMARY KEY,
    stream_uuid text NOT NULL,
    stream_version bigint NOT NULL DEFAULT 0,
    created_at timestamp with time zone NOT NULL DEFAULT now(),
    deleted_at timestamp with time zone
);
```