### PR TITLE
Add documentation for deleting streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ MIT License
   - [Reading from all streams](guides/Usage.md#reading-from-all-streams)
   - [Stream from all streams](guides/Usage.md#stream-from-all-streams)
   - [Linking events between streams](guides/Usage.md#linking-events-between-streams)
-  - [Deleting streams](guides/Usage.md#deleteing-streams)
+  - [Deleting streams](guides/Usage.md#deleting-streams)
 - [Subscriptions](guides/Subscriptions.md)
   - [Transient subscriptions](guides/Subscriptions.md#transient-subscriptions)
   - [Persistent subscriptions](guides/Subscriptions.md#persistent-subscriptions)

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -161,11 +161,15 @@ You can also pass a list of `event_ids` instead of recorded event structs to lin
 
 There are two ways to delete streams. Soft delete and Hard delete.
 
+Use soft delete when you no longer care about a streams events, but want to preserve the full history of events.
+
+Use hard delete when you want a stream to go away more than a bad case of viral gastroenteritis (for example GDPR compliance).
+
 ### Soft delete
 
 Will mark the stream as deleted, but will not delete its events. Events from soft deleted streams will still appear in the globally ordered all events ($all) stream and in any linked streams.
 
-A soft deleted stream cannot be read nor appended to. Subscriptions to the deleted stream will not receive any events.
+A soft deleted stream cannot be read nor appended to. Subscriptions to the deleted stream will not receive any events but subscriptions containing linked events from the deleted stream, such as the global all events stream, will still receive events from the deleted stream.
 
 #### Examples
 
@@ -186,7 +190,7 @@ Delete stream will use soft delete by default so you can omit the type:
 
 ### Hard delete
 
-Will permanently delete the stream and its events. This is irreversible and will remove data. Events will be removed from the globally ordered all events ($all) stream and any linked streams.
+Will permanently delete the stream and its events. **This is irreversible and will remove data**. Events will be removed from the globally ordered all events ($all) stream and any linked streams.
 
 After being hard deleted, a stream can later be appended to and read as if had never existed.
 
@@ -204,7 +208,12 @@ Or via config:
 config :my_app, MyApp.EventStore, enable_hard_deletes: true
 ```
 
-Hard delete a stream:
+Hard delete a stream at any version:
+```elixir
+:ok = MyApp.EventStore.delete_stream("stream1", :any_version, :hard)
+```
+
+Hard delete a stream that should exist:
 ```elixir
 :ok = MyApp.EventStore.delete_stream("stream2", :stream_exists, :hard)
 ```


### PR DESCRIPTION
I found some documentation for this [here](https://hexdocs.pm/eventstore/EventStore.html#c:delete_stream/4) however I still think this is a valuable addition to the usage documentation. 

Maybe a link to [Recipe: GDPR compliance](https://github.com/commanded/recipes/issues/4) would be valuable? I wasn't sure this belonged in the usage guidelines so I left it out. Happy to add that if you would like.