### PR TITLE
Monitor listen_to connection process in Notifications.Listener

### DIFF
--- a/lib/event_store/notifications/listener.ex
+++ b/lib/event_store/notifications/listener.ex
@@ -44,6 +44,14 @@ defmodule EventStore.Notifications.Listener do
     dispatch_events([], state)
   end
 
+  def handle_info({:DOWN, _ref, :process, listen_to, reason}, %{listen_to: listen_to} = state) do
+    {:stop, reason, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
   def handle_demand(incoming_demand, %Listener{} = state) do
     %Listener{demand: pending_demand} = state
 
@@ -62,6 +70,8 @@ defmodule EventStore.Notifications.Listener do
         {:ok, ref} -> ref
         {:eventually, ref} -> ref
       end
+
+    Process.monitor(listen_to)
 
     %Listener{state | ref: ref}
   end


### PR DESCRIPTION
The `listen_to` parameter is the registered name of the `Postgrex.Notifications` process that is used to listen for event notifications. That process is not monitored from `Notifications.Listener`. If the `Postgrex.Notifications` process goes down for any reason, the `Notifications.Listener` module does not call the private function `listen_for_events/1` again. This results in a broken state, where we are no longer listening for event notifications.

The proposed changes monitor the `Postgrex.Notifications` process and react to a DOWN message and stopping the `Notifications.Listener` process with the same reason. The `Notifications.Listener` process is started from a `MonitoredServer` process, and so it is guaranteed to be restarted after stopping.

**Note:** the started `Postgrex.Notifications` process is configured with `auto_connect: true` and so it should (in theory) never go down. But processes should not be trusted like this.