### PR TITLE
Fix documentation type in EventStore Usage Guide

### DIFF
--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -10,7 +10,7 @@ end
 
 ## Writing to a stream
 
-Create a unique identity for each stream. It **must** be a string. This example uses the [elixir_uuid](https://hex.pm/packages/elixir_uuid) package.
+Create a unique identity for each stream. It **must** be a string.
 
 ```elixir
 stream_uuid = EventStore.UUID.uuid4()


### PR DESCRIPTION
Remove reference to `elixir_uuid` package. EventStore includes its own implementation of UUID.