### PR TITLE
Fix warnings over deprecated comment syntax

### DIFF
--- a/lib/event_store/sql/statements/insert_events.sql.eex
+++ b/lib/event_store/sql/statements/insert_events.sql.eex
@@ -1,4 +1,4 @@
-<%#
+<%
   # Elixir template variables:
   #   schema - string
   #   stream_id - integer
@@ -21,7 +21,7 @@
 %>
 
 WITH
-  <%#
+  <%
     # create a table variable with:
     #  event_id - uuid - the id for the new event
     #  index - integer - the increase in the stream version for any stream it is linked to


### PR DESCRIPTION
Hello,

I just got started with EventStore, and after installing it and compiling my project, I got the following warnings:

```
==> eventstore
Compiling 60 files (.ex)
    warning: <%# is deprecated, use <%!-- or add a space between <% and # instead
    │
  1 │ <%#
    │ ~
    │
    └─ lib/event_store/sql/statements/insert_events.sql.eex:1: (file)

    warning: <%# is deprecated, use <%!-- or add a space between <% and # instead
    │
 24 │   <%#
    │   ~
    │
    └─ lib/event_store/sql/statements/insert_events.sql.eex:24: (file)
```

It seemed like a very simple thing to solve – hence, this PR. :)

Thank you for building EventStore and Commanded!