### PR TITLE
Avoid crash of event handler causing abnormal shutdown of subscription process

### DIFF
--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -166,7 +166,7 @@ defmodule EventStore.Subscriptions.Subscription do
       |> apply_subscription_to_state(state)
 
     if unsubscribed?(state) do
-      {:stop, reason, state}
+      {:stop, :normal, state}
     else
       {:noreply, state}
     end


### PR DESCRIPTION
Whenever we have an event handler that crashes, we have the issue that we get an additional, related, but harmless error from Subscription process.
A small Commanded example to illustrate this:
Let's imagine we have an event handler that crashes with a `RuntimeError`. This results in an unhandled exception to be logged:

```elixir
[error] GenServer {Sample.CommandedApp.LocalRegistry, {Sample.CommandedApp, Commanded.Event.Handler, "Sample.Users.Projector"}} terminating
** (stop) %RuntimeError{message: "Error"}
Last message: {:events, [%Commanded.EventStore.RecordedEvent{...}]}
State: %Commanded.Event.Handler{...}
```
This is all good and expected. However, in addition to this, another unhandled exception is logged:
```elixir
GenServer {Sample.EventStore.EventStore.Subscriptions.Registry, {"$all", "Sample.Users.Projector"}} terminating
** (stop) %RuntimeError{message: "Error"}
Last message: {:DOWN, #Reference<0.3446345217.2822766607.9596>, :process, #PID<0.464.0>, %RuntimeError{message: "Error"}}
State: %EventStore.Subscriptions.Subscription{...}
```
As the subscription monitors the subscriber (the `Sample.Users.Projector` event handler in this case), it receives a `:DOWN`-message, when the subscriber crashes. As part of handling this, the subscription stops with the same reason as the subscriber. 
The change that I suggest will stop the subscription with reason `:normal` regardless of the subscriber termination reason.
From what I can tell, this does not have any negative impacts, but will make logs more clear when subscribers crash.